### PR TITLE
Parsing du pseudo prenant en compte le Genesis Pass.

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
@@ -33,7 +33,7 @@ public final class JVCParser {
     private static final Pattern userCanDeleteOrRestoreMessagePattern = Pattern.compile("<span class=\"picto-msg-(croix|restaurer)\" title=\"(Supprimer|Restaurer)\" data-type=\"(delete|restore)\">");
     private static final Pattern userCanEditMessagePattern = Pattern.compile("<span class=\"picto-msg-crayon\" title=\"Editer\">");
     private static final Pattern userCanKickOrDekickAuthorPattern = Pattern.compile("<span class=\"picto-msg-(kick|dekick)\" title=\"(Kicker|Dékicker)\" data-id-alias=\"[^\"]*\">");
-    private static final Pattern pseudoInfosPattern = Pattern.compile("<span class=\"JvCare [^ ]* bloc-pseudo-msg text-([^\"]*)\" target=\"_blank\">[^a-zA-Z0-9_\\[\\]-]*([a-zA-Z0-9_\\[\\]-]*)[^<]*</span>");
+    private static final Pattern pseudoInfosPattern = Pattern.compile("<span class=\"JvCare [^ ]* bloc-pseudo-msg text-([^\"]*)\" target=\"_blank\">[^a-zA-Z0-9_\\[\\]-]*([a-zA-Z0-9_\\[\\]-]*)(?:[^<]*<div class=\"bloc-genesis-pass\"><i class=\"icon-nft-badge\"></i> </div>)?[^<]*</span>");
     private static final Pattern idAliasPattern = Pattern.compile("data-id-alias=\"([0-9]+)\">");
     private static final Pattern messagePattern = Pattern.compile("<div class=\"bloc-contenu\">[^<]*<div class=\"txt-msg +text-[^-]*-forum \">((.*?)(?=<div class=\"info-edition-msg\">)|(.*?)(?=<div class=\"signature-msg)|(.*))", Pattern.DOTALL);
     private static final Pattern currentPagePattern = Pattern.compile("<span class=\"page-active\">([^<]*)</span>");


### PR DESCRIPTION
La précédente regex ne prenait pas en compte l’icône du Genesis Pass (un élément HTML dans l’élément HTML contenant le pseudo), ce qui faisait échouer le parsing et affichait la valeur par défaut « Pseudo supprimé » pour ceux exhibant leur Genesis Pass.

Pour tester, on peut se rendre sur le forum Communauté afin de rapidement trouver un topic contenant un message affichant un Genesis Pass.