### PR TITLE
Juin 2024 - Correction de bugs - Niveaux

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/MainActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/MainActivity.java
@@ -61,6 +61,7 @@ public class MainActivity extends AppCompatActivity {
     private void manageImagesCache() {
         manageThisImageCache("nlsk_mini", 500);
         manageThisImageCache("nlsk_xs", 200);
+        manageThisImageCache("nlsk_md", 20);
         manageThisImageCache("nlsk_big", 5);
         manageThisImageCache("vtr_sm", 500);
     }

--- a/app/src/main/java/com/franckrj/respawnirc/MainActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/MainActivity.java
@@ -5,10 +5,10 @@ import android.content.pm.ShortcutInfo;
 import android.content.pm.ShortcutManager;
 import android.os.Build;
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
 
 import android.webkit.WebView;
 
+import com.franckrj.respawnirc.base.AbsBaseActivity;
 import com.franckrj.respawnirc.jvcforum.SearchTopicInForumActivity;
 import com.franckrj.respawnirc.jvcforumlist.SelectForumInListActivity;
 import com.franckrj.respawnirc.jvcforum.ShowForumActivity;
@@ -22,49 +22,12 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AbsBaseActivity {
     public static final int ACTIVITY_SHOW_FORUM = 0;
     public static final int ACTIVITY_SHOW_TOPIC = 1;
     public static final int ACTIVITY_SELECT_FORUM_IN_LIST = 2;
 
     public static final String ACTION_OPEN_SHORTCUT = "com.franckrj.respawnirc.ACTION_OPEN_SHORTCUT";
-
-    private void manageWebViewCache() {
-        //vidage du cache des webviews
-        if (PrefsManager.getInt(PrefsManager.IntPref.Names.NUMBER_OF_WEBVIEW_OPEN_SINCE_CACHE_CLEARED) > 10) {
-            WebView obj = new WebView(this);
-            obj.clearCache(true);
-            PrefsManager.putInt(PrefsManager.IntPref.Names.NUMBER_OF_WEBVIEW_OPEN_SINCE_CACHE_CLEARED, 0);
-            PrefsManager.applyChanges();
-        }
-    }
-
-    private void manageThisImageCache(String cacheName, int imageNbLimit) {
-        File cacheDir = new File(getCacheDir().getPath() + "/" + cacheName);
-        if (!cacheDir.exists()) {
-            //noinspection ResultOfMethodCallIgnored
-            cacheDir.mkdirs();
-        }
-        File[] listOfImagesCached = cacheDir.listFiles();
-        if (listOfImagesCached != null) {
-            if (listOfImagesCached.length > imageNbLimit) {
-                for (File thisFile : listOfImagesCached) {
-                    if (!thisFile.isDirectory()) {
-                        //noinspection ResultOfMethodCallIgnored
-                        thisFile.delete();
-                    }
-                }
-            }
-        }
-    }
-
-    private void manageImagesCache() {
-        manageThisImageCache("nlsk_mini", 500);
-        manageThisImageCache("nlsk_xs", 200);
-        manageThisImageCache("nlsk_md", 20);
-        manageThisImageCache("nlsk_big", 5);
-        manageThisImageCache("vtr_sm", 500);
-    }
 
     private void manageShortcuts() {
         if (Build.VERSION.SDK_INT >= 25) {

--- a/app/src/main/java/com/franckrj/respawnirc/SettingsFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/SettingsFragment.java
@@ -206,7 +206,17 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
             EditTextPreference editTextPref = (EditTextPreference) pref;
             MinMaxInfos prefMinMax = listOfMinMaxInfos.get(editTextPref.getKey());
             if (prefMinMax != null) {
-                editTextPref.setSummary("Entre " + String.valueOf(prefMinMax.min) + " et " + String.valueOf(prefMinMax.max) + " : " + editTextPref.getText());
+                CharSequence oldSummary = editTextPref.getSummary();
+                String newSummaryStr = "Entre " + String.valueOf(prefMinMax.min) + " et " + String.valueOf(prefMinMax.max) + " : " + editTextPref.getText();
+                if(oldSummary != null) {
+                    String oldSummaryStr = editTextPref.getSummary().toString();
+                    int newLineIndex = oldSummaryStr.indexOf(System.lineSeparator());
+                    if(newLineIndex >= 0) {
+                        newSummaryStr += oldSummaryStr.substring(newLineIndex);
+                    }
+                }
+
+                editTextPref.setSummary(newSummaryStr);
             }
         }
     }

--- a/app/src/main/java/com/franckrj/respawnirc/WebBrowserActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/WebBrowserActivity.java
@@ -46,6 +46,8 @@ public class WebBrowserActivity extends AbsToolbarActivity {
         setContentView(R.layout.activity_webbrowser);
         initToolbar(R.id.toolbar_webbrowser);
 
+        manageWebViewCache();
+
         String cookies = AccountManager.getCurrentAccount().cookie;
 
         /*L'ancienne COOKIES_LIST contenait deux cookies, la nouvelle n'en contient plus qu'un.*/

--- a/app/src/main/java/com/franckrj/respawnirc/base/AbsBaseActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/base/AbsBaseActivity.java
@@ -1,0 +1,49 @@
+package com.franckrj.respawnirc.base;
+
+import android.webkit.WebView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.franckrj.respawnirc.utils.PrefsManager;
+
+import java.io.File;
+
+public abstract class AbsBaseActivity extends AppCompatActivity {
+
+    private void manageThisImageCache(String cacheName, int imageNbLimit) {
+        File cacheDir = new File(getCacheDir().getPath() + "/" + cacheName);
+        if (!cacheDir.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            cacheDir.mkdirs();
+        }
+        File[] listOfImagesCached = cacheDir.listFiles();
+        if (listOfImagesCached != null) {
+            if (listOfImagesCached.length > imageNbLimit) {
+                for (File thisFile : listOfImagesCached) {
+                    if (!thisFile.isDirectory()) {
+                        //noinspection ResultOfMethodCallIgnored
+                        thisFile.delete();
+                    }
+                }
+            }
+        }
+    }
+
+    public void manageImagesCache() {
+        manageThisImageCache("nlsk_mini", 500);
+        manageThisImageCache("nlsk_xs", 200);
+        manageThisImageCache("nlsk_md", 20);
+        manageThisImageCache("nlsk_big", 5);
+        manageThisImageCache("vtr_sm", 500);
+    }
+
+    public void manageWebViewCache() {
+        //vidage du cache des webviews
+        if (PrefsManager.getInt(PrefsManager.IntPref.Names.NUMBER_OF_WEBVIEW_OPEN_SINCE_CACHE_CLEARED) > 10) {
+            WebView obj = new WebView(this);
+            obj.clearCache(true);
+            PrefsManager.putInt(PrefsManager.IntPref.Names.NUMBER_OF_WEBVIEW_OPEN_SINCE_CACHE_CLEARED, 0);
+            PrefsManager.applyChanges();
+        }
+    }
+}

--- a/app/src/main/java/com/franckrj/respawnirc/base/AbsThemedActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/base/AbsThemedActivity.java
@@ -11,7 +11,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.franckrj.respawnirc.R;
 import com.franckrj.respawnirc.utils.ThemeManager;
 
-public abstract class AbsThemedActivity extends AppCompatActivity {
+public abstract class AbsThemedActivity extends AbsBaseActivity {
     protected static ActivityManager.TaskDescription generalTaskDesc = null;
     protected static @ColorInt int colorUsedForGenerateTaskDesc = 0;
     protected ThemeManager.ThemeName lastThemeUsed = null;

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowMessageActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowMessageActivity.java
@@ -411,6 +411,12 @@ public class ShowMessageActivity extends AbsHomeIsBackActivity {
         }
     }
 
+    @Override
+    public void onStart() {
+        super.onStart();
+        manageImagesCache();
+    }
+
     private static class GetMessageToShow extends AbsWebRequestAsyncTask<String, Void, MessageShowedStatusInfos> {
         @Override
         protected MessageShowedStatusInfos doInBackground(String... params) {

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowMessageActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowMessageActivity.java
@@ -212,6 +212,13 @@ public class ShowMessageActivity extends AbsHomeIsBackActivity {
 
         try {
             avatarSizeInDP = PrefsManager.getStringAsInt(PrefsManager.StringPref.Names.AVATAR_SIZE);
+            if(PrefsManager.getBool(PrefsManager.BoolPref.Names.ENABLE_NIVEAU_MODE_FORUM)) {
+                PrefsManager.StringPref avatarSizePref = PrefsManager.getStringInfos(getApplicationContext().getString(R.string.settingsAvatarSize));
+                int minValWithNiveaux = avatarSizePref.minVal + 15;
+                if(avatarSizeInDP < minValWithNiveaux) {
+                    avatarSizeInDP = minValWithNiveaux;
+                }
+            }
         } catch (Exception e) {
             avatarSizeInDP = -1;
         }
@@ -243,7 +250,7 @@ public class ShowMessageActivity extends AbsHomeIsBackActivity {
         convertNoelshackLinkToDirectLink = PrefsManager.getBool(PrefsManager.BoolPref.Names.USE_DIRECT_NOELSHACK_LINK);
         showOverviewOnImageClick = PrefsManager.getBool(PrefsManager.BoolPref.Names.SHOW_OVERVIEW_ON_IMAGE_CLICK);
         fastRefreshOfImages = PrefsManager.getBool(PrefsManager.BoolPref.Names.ENABLE_FAST_REFRESH_OF_IMAGES);
-        currentSettings.firstLineFormat = "<b><%PSEUDO_COLOR_START%><%PSEUDO_PSEUDO%><%PSEUDO_COLOR_END%></b><small><%MARK_FOR_PSEUDO%><br>Le <%DATE_COLOR_START%><%DATE_FULL%><%DATE_COLOR_END%></small>";
+        currentSettings.firstLineFormat = "<b><%PSEUDO_COLOR_START%><%PSEUDO_PSEUDO%><%PSEUDO_COLOR_END%></b><small><%MARK_FOR_PSEUDO%><%NIVEAU_LINE%><br>Le <%DATE_COLOR_START%><%DATE_FULL%><%DATE_COLOR_END%></small>";
         currentSettings.colorPseudoUser = Utils.colorToString(ThemeManager.getColorInt(R.attr.themedPseudoUserColor, this));
         currentSettings.colorPseudoOther = Utils.colorToStringWithAlpha(ThemeManager.getColorInt(R.attr.themedPseudoOtherModeForumColor, this));
         currentSettings.colorPseudoModo = Utils.colorToString(ThemeManager.getColorInt(R.attr.themedPseudoModoColor, this));
@@ -260,6 +267,7 @@ public class ShowMessageActivity extends AbsHomeIsBackActivity {
         currentSettings.pseudoOfUser = AccountManager.getCurrentAccount().pseudo;
         currentSettings.typeOfPseudoToColorInInfoLine.setTypeFromString(PrefsManager.getString(PrefsManager.StringPref.Names.TYPE_OF_PSEUDO_TO_COLOR_IN_INFO));
         currentSettings.typeOfPseudoToColorInMessage.setTypeFromString(PrefsManager.getString(PrefsManager.StringPref.Names.TYPE_OF_PSEUDO_TO_COLOR_IN_MESSAGE));
+        currentSettings.enableNiveauModeForum = PrefsManager.getBool(PrefsManager.BoolPref.Names.ENABLE_NIVEAU_MODE_FORUM);
         adapterForTopic.setShowSpoilDefault(PrefsManager.getBool(PrefsManager.BoolPref.Names.DEFAULT_SHOW_SPOIL_VAL));
         adapterForTopic.setColorDeletedMessages(PrefsManager.getBool(PrefsManager.BoolPref.Names.ENABLE_COLOR_DELETED_MESSAGES));
         adapterForTopic.setMessageFontSizeInSp(PrefsManager.getStringAsInt(PrefsManager.StringPref.Names.MESSAGE_FONT_SIZE));

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowTopicActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowTopicActivity.java
@@ -1031,6 +1031,14 @@ public class ShowTopicActivity extends AbsHomeIsBackActivity implements AbsShowT
                 myActionBar.setSubtitle(Utils.applyEmojiCompatIfPossible(topicStatus.names.topic));
             }
         }
+
+        /* Certains appareils effacent le cache pendant que l'application fonctionne quand l'espace disque est bas.
+         * Il faut donc vérifier le cache à chaque rafraîchissement.
+         * Ce n'est pas le meilleur endroit mais c'est celui qui garantit que tous les rafraîchissements sont couverts.
+         * onResume()/onStart() ne conviennent que lors de l'entrée initiale sur un topic ou quand l'utilisateur
+         * revient sur l'application mais pas lors d'un rafraîchissement.
+         */
+        manageImagesCache();
     }
 
     @Override

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicgetters/AbsJVCTopicGetter.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicgetters/AbsJVCTopicGetter.java
@@ -140,8 +140,13 @@ public abstract class AbsJVCTopicGetter {
         boolean pageDownloadedIsAnalysable = true;
 
         if (!newPageInfos.newUrlForTopicPage.isEmpty()) {
+            // 2024-06-18 : Les IDs dans l'adresse URL des topics pré-Respawn ne correspondent plus entre la liste des sujets et le topic en lui-même.
+            //              Précédemment, le code vérifiait que l'ID entre la page demandée et la page reçue correspondent.
+            //              Quand un topic n'existe pas, le site redirige vers la page principale des forums.
+            //              Il me semble donc correct de seulement vérifier si l'ID existe plutôt que son égalité.
+            //              Si le topic n'existe pas, l'ID sera vide suite à la redirection donc ce code fonctionne quand même. -Fox
             if (JVCParser.checkIfItsTopicFormatedLink(newPageInfos.newUrlForTopicPage)
-                    && Utils.stringsAreEquals(JVCParser.getTopicIdOfThisTopic(urlForTopicPage), JVCParser.getTopicIdOfThisTopic(newPageInfos.newUrlForTopicPage))) {
+                    && !Utils.stringIsEmptyOrNull(JVCParser.getTopicIdOfThisTopic(urlForTopicPage)) && !Utils.stringIsEmptyOrNull(JVCParser.getTopicIdOfThisTopic(newPageInfos.newUrlForTopicPage))) {
                 if (JVCParser.getPageNumberForThisTopicLink(urlForTopicPage).equals(JVCParser.getPageNumberForThisTopicLink(newPageInfos.newUrlForTopicPage))) {
                     urlForTopicPage = newPageInfos.newUrlForTopicPage;
                     if (listenerForTopicLinkChanged != null) {
@@ -152,6 +157,8 @@ public abstract class AbsJVCTopicGetter {
                     pageDownloadedIsAnalysable = false;
                 }
             } else {
+                System.err.println(JVCParser.getTopicIdOfThisTopic(urlForTopicPage));
+                System.err.println(JVCParser.getTopicIdOfThisTopic(newPageInfos.newUrlForTopicPage));
                 lastTypeOfError = ErrorType.TOPIC_DOES_NOT_EXIST;
                 pageDownloadedIsAnalysable = false;
             }

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicgetters/AbsJVCTopicGetter.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicgetters/AbsJVCTopicGetter.java
@@ -157,8 +157,6 @@ public abstract class AbsJVCTopicGetter {
                     pageDownloadedIsAnalysable = false;
                 }
             } else {
-                System.err.println(JVCParser.getTopicIdOfThisTopic(urlForTopicPage));
-                System.err.println(JVCParser.getTopicIdOfThisTopic(newPageInfos.newUrlForTopicPage));
                 lastTypeOfError = ErrorType.TOPIC_DOES_NOT_EXIST;
                 pageDownloadedIsAnalysable = false;
             }

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
@@ -165,6 +165,13 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
 
         try {
             avatarSizeInDP = PrefsManager.getStringAsInt(PrefsManager.StringPref.Names.AVATAR_SIZE);
+            if(PrefsManager.getBool(PrefsManager.BoolPref.Names.ENABLE_NIVEAU_MODE_FORUM)) {
+                PrefsManager.StringPref avatarSizePref = PrefsManager.getStringInfos(getContext().getString(R.string.settingsAvatarSize));
+                int minValWithNiveaux = avatarSizePref.minVal + 15;
+                if(avatarSizeInDP < minValWithNiveaux) {
+                    avatarSizeInDP = minValWithNiveaux;
+                }
+            }
         } catch (Exception e) {
             avatarSizeInDP = -1;
         }
@@ -200,6 +207,7 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
         currentSettings.pseudoOfUser = AccountManager.getCurrentAccount().pseudo;
         currentSettings.typeOfPseudoToColorInInfoLine.setTypeFromString(PrefsManager.getString(PrefsManager.StringPref.Names.TYPE_OF_PSEUDO_TO_COLOR_IN_INFO));
         currentSettings.typeOfPseudoToColorInMessage.setTypeFromString(PrefsManager.getString(PrefsManager.StringPref.Names.TYPE_OF_PSEUDO_TO_COLOR_IN_MESSAGE));
+        currentSettings.enableNiveauModeForum = PrefsManager.getBool(PrefsManager.BoolPref.Names.ENABLE_NIVEAU_MODE_FORUM);
         absGetterForTopic.setCookieListInAString(AccountManager.getCurrentAccount().cookie);
         smoothScrollIsEnabled = PrefsManager.getBool(PrefsManager.BoolPref.Names.ENABLE_SMOOTH_SCROLL);
         adapterForTopic.setShowSpoilDefault(PrefsManager.getBool(PrefsManager.BoolPref.Names.DEFAULT_SHOW_SPOIL_VAL));

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicModeForumFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicModeForumFragment.java
@@ -98,7 +98,7 @@ public class ShowTopicModeForumFragment extends AbsShowTopicFragment {
     protected void initializeSettings() {
         super.initializeSettings();
         showRefreshWhenMessagesShowed = true;
-        currentSettings.firstLineFormat = "<b><%PSEUDO_COLOR_START%><%PSEUDO_PSEUDO%><%PSEUDO_COLOR_END%></b><small><%MARK_FOR_PSEUDO%><br>Le <%DATE_COLOR_START%><%DATE_FULL%><%DATE_COLOR_END%></small>";
+        currentSettings.firstLineFormat = "<b><%PSEUDO_COLOR_START%><%PSEUDO_PSEUDO%><%PSEUDO_COLOR_END%></b><small><%MARK_FOR_PSEUDO%><%NIVEAU_LINE%><br>Le <%DATE_COLOR_START%><%DATE_FULL%><%DATE_COLOR_END%></small>";
         currentSettings.colorPseudoUser = Utils.colorToString(ThemeManager.getColorInt(R.attr.themedPseudoUserColor, requireActivity()));
         currentSettings.colorPseudoOther = Utils.colorToStringWithAlpha(ThemeManager.getColorInt(R.attr.themedPseudoOtherModeForumColor, requireActivity()));
         currentSettings.colorPseudoModo = Utils.colorToString(ThemeManager.getColorInt(R.attr.themedPseudoModoColor, requireActivity()));

--- a/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
@@ -102,6 +102,7 @@ public final class JVCParser {
     private static final Pattern longJvcLinkPattern = Pattern.compile("<a +title=\"[^\"]*\" +href=\"([^\"]*)\"[^>]*>[^<]*<i></i><span>[^<]*</span>[^<]*</a>");
     private static final Pattern shortLinkPattern = Pattern.compile("<span +class=\"JvCare [^\"]*\"[^>]*?target=\"_blank\"[^>]*>([^<]*)</span>");
     private static final Pattern longLinkPattern = Pattern.compile("<span +class=\"JvCare [^\"]*\"[^i]*itle=\"([^\"]*)\"[^>]*>[^<]*<i></i><span>[^<]*</span>[^<]*</span>");
+    private static final Pattern alloCineLinkPattern = Pattern.compile("<a +target=\"[^\"]*\" +title=\"[^\"]*\" +href=\"([^\"]*)\"[^>]*>[^<]*<i></i><span>[^<]*</span>[^<]*</a>");
     private static final Pattern textLinkPattern = Pattern.compile("http(s)?://[a-zA-Z0-9/%._~!$&'()*+,;=:@?#-]*(?![^<>]*(>|</a>))", Pattern.CASE_INSENSITIVE);
     private static final Pattern smileyPattern = Pattern.compile("<img src=\"http(s)?://image\\.jeuxvideo\\.com/smileys_img/([^\"]*)\" alt=\"[^\"]*\" data-code=\"([^\"]*)\" title=\"[^\"]*\" [^>]*>");
     private static final Pattern embedVideoPattern = Pattern.compile("<div class=\"player-contenu\"><div class=\"[^\"]*\"><iframe.*?src=\"([^\"]*)\"[^>]*></iframe></div></div>");
@@ -1122,6 +1123,7 @@ public final class JVCParser {
         ToolForParsing.parseThisMessageWithThisPattern(messageInBuilder, longJvcLinkPattern, 1, "", "", makeLinkDependingOnSettingsAndForceMake, null);
         ToolForParsing.parseThisMessageWithThisPattern(messageInBuilder, shortLinkPattern, 1, "", "", makeLinkDependingOnSettingsAndForceMake, null);
         ToolForParsing.parseThisMessageWithThisPattern(messageInBuilder, longLinkPattern, 1, "", "", makeLinkDependingOnSettingsAndForceMake, null);
+        ToolForParsing.parseThisMessageWithThisPattern(messageInBuilder, alloCineLinkPattern, 1, "", "", makeLinkDependingOnSettingsAndForceMake, null);
 
         if (settings.hideUglyImages && !showUglyImages) {
             ToolForParsing.parseThisMessageWithThisPattern(messageInBuilder, noelshackImagePattern, 0, "", "", new SuppressIfContainUglyNames(), null);

--- a/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
@@ -114,6 +114,7 @@ public final class JVCParser {
     private static final Pattern userCanLockOrUnlockTopicPattern = Pattern.compile("<span class=\"btn btn-forum-modo btn-lock-topic\" data-type=\"(un)?lock\">");
     private static final Pattern userCanPinOrUnpinTopicPattern = Pattern.compile("<span class=\"btn btn-forum-modo btn-epingle-topic\" data-type=\"(des)?epingle\">");
     private static final Pattern uglyImagesNamePattern = Pattern.compile("issou|risi|rizi|jesus|picsart|chancla|larry|sermion");
+    private static final Pattern jvcNiveauPattern = Pattern.compile("<div +class=\"bloc-user-level[^\"]*\">(.*?)Niveau ([0-9]*)(.*?)</div>", Pattern.DOTALL);
     private static final Pattern adPattern = Pattern.compile("<ins[^>]*></ins>");
     private static final Pattern htmlTagPattern = Pattern.compile("<.+?>");
     private static final Pattern multipleSpacesPattern = Pattern.compile(" +");
@@ -1045,6 +1046,14 @@ public final class JVCParser {
         ToolForParsing.replaceStringByAnother(newFirstLine, "<%DATE_FULL%>", thisMessageInfo.wholeDate);
         ToolForParsing.replaceStringByAnother(newFirstLine, "<%PSEUDO_PSEUDO%>", (thisMessageInfo.pseudoIsBlacklisted ? "Auteur blacklisté" : thisMessageInfo.pseudo));
 
+        if(settings.enableNiveauModeForum && !Utils.stringIsEmptyOrNull(thisMessageInfo.niveau)) {
+            ToolForParsing.replaceStringByAnother(newFirstLine, "<%NIVEAU_LINE%>", "<br>Niveau " + thisMessageInfo.niveau);
+        }
+        else
+        {
+            ToolForParsing.replaceStringByAnother(newFirstLine, "<%NIVEAU_LINE%>", "");
+        }
+
         if (thisMessageInfo.isAnEdit) {
             ToolForParsing.replaceStringByAnother(newFirstLine, "<%DATE_COLOR_START%>", "<font color=\"#008000\">");
             ToolForParsing.replaceStringByAnother(newFirstLine, "<%DATE_COLOR_END%>", "</font>");
@@ -1233,6 +1242,7 @@ public final class JVCParser {
         Matcher dateMessageMatcher = dateMessagePattern.matcher(thisEntireMessage);
         Matcher lastEditMessageMatcher = lastEditMessagePattern.matcher(thisEntireMessage);
         Matcher messageIdMatcher = messageIdPattern.matcher(thisEntireMessage);
+        Matcher niveauMatcher = jvcNiveauPattern.matcher(thisEntireMessage);
 
         newMessageInfo.pseudoIsBlacklisted = pseudoIsBlacklistedMatcher.find();
         newMessageInfo.messageIsDeleted = messageIsDeletedMatcher.find();
@@ -1272,6 +1282,10 @@ public final class JVCParser {
         if (dateMessageMatcher.find()) {
             newMessageInfo.dateTime = dateMessageMatcher.group(3);
             newMessageInfo.wholeDate = dateMessageMatcher.group(2);
+        }
+
+        if(niveauMatcher.find()) {
+            newMessageInfo.niveau = niveauMatcher.group(2);
         }
 
         if (messageMatcher.find()) {
@@ -1704,6 +1718,7 @@ public final class JVCParser {
         public String messageNotParsed = "";
         public String signatureNotParsed = "";
         public String avatarLink = "";
+        public String niveau = "";
         public String dateTime = "";
         public String wholeDate = "";
         public String lastTimeEdit = "";
@@ -2180,6 +2195,7 @@ public final class JVCParser {
         public boolean shortenLongLink = false;
         public boolean hideUglyImages = false;
         public boolean enableAlphaInNoelshackMini = false;
+        public boolean enableNiveauModeForum = true;
     }
 
     private static class SpoilTagsInfos {

--- a/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
@@ -44,7 +44,7 @@ public final class JVCParser {
     private static final Pattern dateMessagePattern = Pattern.compile("<div class=\"bloc-date-msg\">([^<]*<span class=\"JvCare [^ ]* lien-jv\" target=\"_blank\">)?[^a-zA-Z0-9]*([^ ]* [^ ]* [^ ]* [^ ]* ([0-9:]*))");
     private static final Pattern messageIdPattern = Pattern.compile("<div class=\"bloc-message-forum[^\"]*\" data-id=\"([0-9]*)[^\"]*\">");
     private static final Pattern unicodeInTextPattern = Pattern.compile("\\\\u([a-zA-Z0-9]{4})");
-    private static final Pattern alertPattern = Pattern.compile("<div class=\"alert-row\">([^<]*)</div>");
+    private static final Pattern alertPattern = Pattern.compile("<div class=\"alert alert-danger[^\"]*\">.*?<p class=\"([^\"]*)\">([^<]*)</p>.*?</div>", Pattern.DOTALL);
     private static final Pattern errorBlocPattern = Pattern.compile("<div class=\"bloc-erreur\">([^<]*)</div>");
     private static final Pattern errorInJsonModePattern = Pattern.compile("\"(erreur|error)(s)?\":(\\[)?\"([^\"]*)\"");
     private static final Pattern subIdInJsonPattern = Pattern.compile("\"id-abonnement\":([0-9]*)");
@@ -802,7 +802,7 @@ public final class JVCParser {
         Matcher errorMatcher = alertPattern.matcher(pageSource);
 
         if (errorMatcher.find()) {
-            return "Erreur : " + specialCharToNormalChar(errorMatcher.group(1)).trim();
+            return "Erreur : " + specialCharToNormalChar(errorMatcher.group(2)).trim();
         } else {
             return "Erreur : le message n'a pas été envoyé.";
         }
@@ -817,13 +817,13 @@ public final class JVCParser {
             Matcher alertMatcher = alertPattern.matcher(pageSource);
 
             if (alertMatcher.find()) {
-                if (!alertMatcher.group(1).trim().isEmpty()) {
+                if (!alertMatcher.group(2).trim().isEmpty()) {
                     return "";
                 }
             }
         }
 
-        return "Erreur : la connexion à échouée.";
+        return "Erreur : la connexion a échoué.";
     }
 
     public static String getErrorMessageInJsonMode(String pageSource) {

--- a/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
@@ -156,7 +156,7 @@ public final class JVCParser {
             return baseLink;
         }
 
-        if (baseLink.startsWith("fichiers/") || baseLink.startsWith("fichiers-xs/") || baseLink.startsWith("minis/")) {
+        if (baseLink.startsWith("fichiers/") || baseLink.startsWith("fichiers-xs/") || baseLink.startsWith("fichiers-md/") || baseLink.startsWith("minis/")) {
             baseLink = baseLink.substring(baseLink.indexOf("/") + 1);
         } else {
             baseLink = baseLink.replaceFirst("-", "/").replaceFirst("-", "/");

--- a/app/src/main/java/com/franckrj/respawnirc/utils/PrefsManager.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/PrefsManager.java
@@ -116,6 +116,7 @@ public class PrefsManager {
         addBoolPref(BoolPref.Names.REFRESH_FORUM_ON_RESUME, currentContext.getString(R.string.settingsRefreshForumOnResume), false);
         addBoolPref(BoolPref.Names.ENABLE_ALPHA_IN_NOELSHACK_MINI, currentContext.getString(R.string.settingsEnableAlphaInNoelshackMini), false);
         addBoolPref(BoolPref.Names.BRIGHTEN_ALT_COLOR, currentContext.getString(R.string.settingsBrightenAltColor), false);
+        addBoolPref(BoolPref.Names.ENABLE_NIVEAU_MODE_FORUM, currentContext.getString(R.string.settingsEnableNiveauModeForum), true);
 
         addIntPref(IntPref.Names.HEADER_COLOR_OF_LIGHT_THEME, currentContext.getString(R.string.settingsHeaderColorOfLightTheme), Undeprecator.resourcesGetColor(currentContext.getResources(), R.color.defaultHeaderColorThemeLight));
         addIntPref(IntPref.Names.PRIMARY_COLOR_OF_LIGHT_THEME, currentContext.getString(R.string.settingsPrimaryColorOfLightTheme), 0);
@@ -334,7 +335,8 @@ public class PrefsManager {
             USE_LAST_MESSAGE_DRAFT_SAVED, USE_LAST_TOPIC_DRAFT_SAVED,
             REFRESH_FORUM_ON_RESUME,
             ENABLE_ALPHA_IN_NOELSHACK_MINI,
-            BRIGHTEN_ALT_COLOR
+            BRIGHTEN_ALT_COLOR,
+            ENABLE_NIVEAU_MODE_FORUM
         }
     }
 

--- a/app/src/main/java/com/franckrj/respawnirc/utils/Utils.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/Utils.java
@@ -121,6 +121,8 @@ public class Utils {
             return "nlsk_mini/" + link.substring(("https://image.noelshack.com/minis/").length()).replace("/", "_");
         } else if (link.startsWith("https://image.noelshack.com/fichiers-xs/")) {
             return "nlsk_xs/" + link.substring(("https://image.noelshack.com/fichiers-xs/").length()).replace("/", "_");
+        } else if (link.startsWith("https://image.noelshack.com/fichiers-md/")) {
+            return "nlsk_md/" + link.substring(("https://image.noelshack.com/fichiers-md/").length()).replace("/", "_");
         } else if (link.startsWith("https://image.noelshack.com/fichiers/")) {
             return "nlsk_big/" + link.substring(("https://image.noelshack.com/fichiers/").length()).replace("/", "_");
         } else if (link.startsWith("https://image.jeuxvideo.com/avatar")) {

--- a/app/src/main/java/com/franckrj/respawnirc/utils/WebManager.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/WebManager.java
@@ -9,7 +9,7 @@ import java.net.URL;
 import java.util.concurrent.Callable;
 
 public class WebManager {
-    public static final String userAgentString = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0";
+    public static final String userAgentString = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0";
 
     public static String sendRequestWithMultipleTrys(String linkToPage, String requestMethod, String requestParameters, WebInfos currentInfos, int maxNumberOfTrys) {
         int numberOfTrys = 0;

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -66,4 +66,5 @@
     <string name="settingsTypeOfPseudoToColorInInfo" translatable="false">settings.typeOfPseudoToColorInInfo</string>
     <string name="settingsTypeOfPseudoToColorInMessage" translatable="false">settings.typeOfPseudoToColorInMessage</string>
     <string name="settingsPseudoUserColorOfLightTheme" translatable="false">settings.customColor.pseudoUserColorOfLightTheme</string>
+    <string name="settingsEnableNiveauModeForum" translatable="false">settings.enableNiveauModeForum</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,6 +324,7 @@
     <string name="accountList">Liste des comptes</string>
     <string name="noAccountInList">La liste des comptes est vide.</string>
     <string name="mainForum">Forum principal</string>
+    <string name="enableNiveauModeForum">Afficher les niveaux</string>
 
     <string-array name="choicesForLinkMenu">
         <item>@string/openInExternalBrowser</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,6 +325,7 @@
     <string name="noAccountInList">La liste des comptes est vide.</string>
     <string name="mainForum">Forum principal</string>
     <string name="enableNiveauModeForum">Afficher les niveaux</string>
+    <string name="avatarSizeNiveauSummary">\n(Si les niveaux sont activés, le minimum est 55.)</string>
 
     <string-array name="choicesForLinkMenu">
         <item>@string/openInExternalBrowser</item>

--- a/app/src/main/res/xml/imagelink_settings.xml
+++ b/app/src/main/res/xml/imagelink_settings.xml
@@ -8,7 +8,7 @@
             android:key="@string/settingsAvatarSize"
             android:numeric="integer"
             android:title="@string/avatarSizeTitle"
-            app:summary="\n(Si les niveaux sont activés, le minimum est 55.)" />
+            app:summary="@string/avatarSizeNiveauSummary" />
 
         <EditTextPreference
             android:key="@string/settingsStickerSize"

--- a/app/src/main/res/xml/imagelink_settings.xml
+++ b/app/src/main/res/xml/imagelink_settings.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory
         android:title="@string/avatarsAndStickers">
         <EditTextPreference
             android:key="@string/settingsAvatarSize"
+            android:numeric="integer"
             android:title="@string/avatarSizeTitle"
-            android:numeric="integer"/>
+            app:summary="\n(Si les niveaux sont activés, le minimum est 55.)" />
 
         <EditTextPreference
             android:key="@string/settingsStickerSize"

--- a/app/src/main/res/xml/message_settings.xml
+++ b/app/src/main/res/xml/message_settings.xml
@@ -35,12 +35,19 @@
     <PreferenceCategory
         android:title="@string/settingsModeForumTitle">
         <ListPreference
-            android:key="@string/settingsShowAvatarModeForum"
-            android:title="@string/showAvatarTitle"
-            android:summary="@string/needToBeEnabledOnJVCFirstSummaryWithString"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:entries="@array/choicesForConnectionReadable"
-            android:entryValues="@array/threeChoicesValue"/>
+            android:entryValues="@array/threeChoicesValue"
+            android:key="@string/settingsShowAvatarModeForum"
+            android:summary="@string/needToBeEnabledOnJVCFirstSummaryWithString"
+            android:title="@string/showAvatarTitle" />
 
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:key="@string/settingsEnableNiveauModeForum"
+            android:title="@string/enableNiveauModeForum" />
         <CheckBoxPreference
             android:key="@string/settingsShowSignatureModeForum"
             android:title="@string/showSignatureTitle"


### PR DESCRIPTION
## Attention : Version non changée dans build.gradle car je ne sais pas si 3.1.10 ou 3.2.0 est souhaité.

### Ajouts
* Prise en charge des niveaux (désactivable dans les options)
![Capture d’écran du 2024-06-19 15-43-33](https://github.com/FranckRJ/RespawnIRC-Android/assets/47003797/5b6e25a2-e074-43b0-a16a-36b0dc0bca90)


### Bugs corrigés
* Erreur « Le topic ne semble pas exister » pour les topics pré-Respawn corrigée
* Images Noelshack « fichiers-md » désormais chargées correctement
* Images cessant de fonctionner quand le cache est effacé corrigées
* Liens AllôCiné cassés corrigés
* Messages d'erreur lors de l'envoi d'un message corrigés

### Changements techniques
* User-Agent mis à jour de Firefox 102 à Firefox 128.
* L'application vérifie désormais l'état du cache des images à chaque actualisation de topic pour éviter les problèmes liés aux appareils agressifs qui effacent le cache pendant l'exécution quand l'espace de stockage est bas.