### PR TITLE
Mitigation blocages CloudFlare à la connexion

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/ConnectActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/ConnectActivity.java
@@ -1,7 +1,5 @@
 package com.franckrj.respawnirc;
 
-import static com.franckrj.respawnirc.utils.WebManager.userAgentString;
-
 import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.os.Bundle;
@@ -38,7 +36,6 @@ public class ConnectActivity extends AbsHomeIsBackActivity {
 
     private final View.OnClickListener saveCookieClickedListener = view -> {
         String allCookiesInstring = CookieManager.getInstance().getCookie("https://www.jeuxvideo.com/");
-        Utils.saveCloudflareCookies(allCookiesInstring, false); // On enregistre les cookies CloudFlare dans tous les cas.
         if (!pseudoText.getText().toString().isEmpty()) {
             String[] allCookiesInStringArray = TextUtils.split(allCookiesInstring, ";");
             String connectCookieValue = null;
@@ -90,11 +87,9 @@ public class ConnectActivity extends AbsHomeIsBackActivity {
         helpDialogFragment = new HelpConnectDialogFragment();
         saveCookieButton.setOnClickListener(saveCookieClickedListener);
 
-        /* On nettoie les cookies pour permettre l'authentification. */
-        /* On veut néanmoins préserver les cookies CloudFlare.       */
-        Utils.cleanExpiredCookies();
+        /* On efface tous les cookies de la WebView pour se déconnecter.   */
+        /* On perd les cookies CloudFlare de la WebView mais pas le choix. */
         CookieManager.getInstance().removeAllCookies(null);
-        Utils.setCloudflareCookiesInWebView();
 
         jvcWebView.setWebViewClient(new WebViewClient() {
             @Override
@@ -107,7 +102,6 @@ public class ConnectActivity extends AbsHomeIsBackActivity {
         jvcWebView.setWebChromeClient(new WebChromeClient());
         jvcWebView.getSettings().setJavaScriptEnabled(true);
         jvcWebView.getSettings().setDomStorageEnabled(true);
-        jvcWebView.getSettings().setUserAgentString(userAgentString);
         Undeprecator.webSettingsSetSaveFormData(jvcWebView.getSettings(), false);
         Undeprecator.webSettingsSetSavePassword(jvcWebView.getSettings(), false);
         jvcWebView.clearCache(true);

--- a/app/src/main/java/com/franckrj/respawnirc/WebBrowserActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/WebBrowserActivity.java
@@ -34,6 +34,7 @@ public class WebBrowserActivity extends AbsToolbarActivity {
     private String currentUrl = "";
     private String currentTitle = "";
     private boolean isCfConfirmation = false;
+    private String cookiesWebView = "";
 
     private void updateTitleAndSubtitle() {
         ActionBar myActionBar = getSupportActionBar();
@@ -74,14 +75,19 @@ public class WebBrowserActivity extends AbsToolbarActivity {
 
                 // On sauvegarde les cookies CloudFlare reçus dans la réponse HTTP quand une page commence à charger.
                 // Quand l'utilisateur valide un captcha CloudFlare, la page JVC est rechargée et ce code est exécuté.
-                boolean cfAutorise = Utils.saveCloudflareCookies(CookieManager.getInstance().getCookie("https://jeuxvideo.com/"), false);
-                if(cfAutorise)
+                if(isCfConfirmation)
                 {
-                    Toast.makeText(WebBrowserActivity.this, R.string.cloudflareOK, Toast.LENGTH_LONG).show();
-
-                    // Si on a ouvert le navigateur interne uniquement pour le captcha, on le referme maintenant.
-                    if(isCfConfirmation)
+                    boolean cfAutorise = Utils.saveCloudflareCookies(CookieManager.getInstance().getCookie("https://.jeuxvideo.com/"), false);
+                    if(cfAutorise)
                     {
+                        Toast.makeText(WebBrowserActivity.this, R.string.cloudflareOK, Toast.LENGTH_LONG).show();
+
+                        // On restaure les cookies d'origine de la WebView...
+                        CookieManager.getInstance().removeAllCookies(null);
+                        if(cookiesWebView != null)
+                        {
+                            CookieManager.getInstance().setCookie("https://.jeuxvideo.com", cookiesWebView);
+                        }
                         finish();
                     }
                 }
@@ -109,12 +115,29 @@ public class WebBrowserActivity extends AbsToolbarActivity {
         browserWebView.getSettings().setDomStorageEnabled(true);
         Undeprecator.webSettingsSetSaveFormData(browserWebView.getSettings(), false);
         Undeprecator.webSettingsSetSavePassword(browserWebView.getSettings(), false);
-        browserWebView.getSettings().setUserAgentString(userAgentString);
 
         currentTitle = getString(R.string.app_name);
         if (getIntent() != null && savedInstanceState == null) {
             String newUrlToLoad = getIntent().getStringExtra(EXTRA_URL_LOAD);
             this.isCfConfirmation = getIntent().getBooleanExtra(IS_CF_CONFIRMATION, false);
+
+            if(this.isCfConfirmation)
+            {
+                // On sauvegarde les cookies de la WebView normale.
+                //
+                // En effet, les cookies CloudFlare ne fonctionnent que sur
+                // le User-Agent qui a résolu le captcha.
+                //
+                // Pour une confirmation CF de l'appli, on doit changer
+                // le User-Agent de la WebView par celui de Firefox.
+                //
+                // En revanche, dans les autres cas on veut utiliser la WebView
+                // normale. En effet, la WebView avec le User-Agent Firefox
+                // ne passe pas les captchas Turnstile de connexion et de DDB.
+                cookiesWebView = CookieManager.getInstance().getCookie("https://.jeuxvideo.com");
+                CookieManager.getInstance().removeAllCookies(null);
+                browserWebView.getSettings().setUserAgentString(userAgentString);
+            }
 
             if (!Utils.stringIsEmptyOrNull(newUrlToLoad)) {
                 currentUrl = newUrlToLoad;

--- a/app/src/main/java/com/franckrj/respawnirc/WebBrowserActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/WebBrowserActivity.java
@@ -81,13 +81,6 @@ public class WebBrowserActivity extends AbsToolbarActivity {
                     if(cfAutorise)
                     {
                         Toast.makeText(WebBrowserActivity.this, R.string.cloudflareOK, Toast.LENGTH_LONG).show();
-
-                        // On restaure les cookies d'origine de la WebView...
-                        CookieManager.getInstance().removeAllCookies(null);
-                        if(cookiesWebView != null)
-                        {
-                            CookieManager.getInstance().setCookie("https://.jeuxvideo.com", cookiesWebView);
-                        }
                         finish();
                     }
                 }
@@ -175,6 +168,17 @@ public class WebBrowserActivity extends AbsToolbarActivity {
 
     @Override
     public void onDestroy() {
+        // On restaure toujours les cookies d'origine de la WebView
+        // si on était en authentification CloudFlare...
+        if(isCfConfirmation)
+        {
+            CookieManager.getInstance().removeAllCookies(null);
+            if(cookiesWebView != null)
+            {
+                CookieManager.getInstance().setCookie("https://.jeuxvideo.com", cookiesWebView);
+            }
+        }
+
         browserWebView.destroy();
         super.onDestroy();
     }

--- a/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
@@ -3,7 +3,6 @@ package com.franckrj.respawnirc.utils;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.Base64;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.collection.ArraySet;
@@ -14,8 +13,6 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/app/src/main/java/com/franckrj/respawnirc/utils/Utils.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/Utils.java
@@ -20,17 +20,14 @@ import android.graphics.drawable.Icon;
 import android.net.Uri;
 import android.text.Spannable;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.CookieManager;
 import android.widget.EditText;
-import android.widget.Toast;
 
 import androidx.annotation.ColorInt;
 import androidx.emoji.text.EmojiCompat;
 
-import com.franckrj.respawnirc.ConnectActivity;
 import com.franckrj.respawnirc.MainActivity;
 import com.franckrj.respawnirc.R;
 import com.franckrj.respawnirc.WebBrowserActivity;
@@ -387,44 +384,6 @@ public class Utils {
         }
 
         return res;
-    }
-
-    /**
-     * Vérifie les cookies de la WebView et retire les cookies expirés
-     * du reste de l'application (cookies CloudFlare notamment).
-     *
-     * Idéalement, on pourrait détecter si le cookie de connexion a expiré
-     * et permettre à l'utilisateur de se reconnecter mais j'ai la flemme. -Fox
-     */
-    public static void cleanExpiredCookies() {
-        boolean cfBmCookieExists = false, cfClearanceCookieExists = false;
-        String cookies = CookieManager.getInstance().getCookie("https://.jeuxvideo.com");
-        if(cookies != null) {
-            String[] allCookiesInStringArray = TextUtils.split(cookies, ";");
-            for (String thisCookie : allCookiesInStringArray) {
-                String[] cookieInfos;
-
-                thisCookie = thisCookie.trim();
-                cookieInfos = TextUtils.split(thisCookie, "=");
-
-                if (cookieInfos.length > 1) {
-                    if (cookieInfos[0].equals("__cf_bm")) {
-                        cfBmCookieExists = true;
-                    } else if (cookieInfos[0].equals("cf_clearance")) {
-                        cfClearanceCookieExists = true;
-                    }
-                }
-            }
-        }
-
-        if(!cfBmCookieExists) {
-            PrefsManager.putString(PrefsManager.StringPref.Names.CLOUDFLARE_BOT_PROTECTION, "");
-            PrefsManager.applyChanges();
-        }
-        if(!cfClearanceCookieExists) {
-            PrefsManager.putString(PrefsManager.StringPref.Names.CLOUDFLARE_CLEARANCE, "");
-            PrefsManager.applyChanges();
-        }
     }
 
     /**

--- a/app/src/main/java/com/franckrj/respawnirc/utils/WebManager.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/WebManager.java
@@ -75,9 +75,6 @@ public class WebManager {
                 urlConnection.setReadTimeout(5_000);
             }
 
-            /* On nettoie nos cookies potentiellement expirés. */
-            Utils.cleanExpiredCookies();
-
             // On ajoute les cookies...
             cookie = Utils.buildCloudflareCookieString();
             if(cookie.isEmpty()) {
@@ -153,7 +150,7 @@ public class WebManager {
                 }
 
                 if(headerName != null && headerName.equals("Set-Cookie")) {
-                    Utils.saveCloudflareCookies(headerValue, true);
+                    Utils.saveCloudflareCookies(headerValue, false);
                 }
             }
 


### PR DESCRIPTION
Il y a désormais un jonglage entre les cookies CloudFlare et les User-Agents pour gérer à la fois les écrans d'accès CloudFlare et les formulaires de connexion.

En outre, on utilise la WebView avec le User-Agent par défaut (comportement classique) pour toutes les pages. La WebView gère ses propres cookies CloudFlare.

Quand on tombe sur un blocage CloudFlare pour la navigation, on sauvegarde les cookies du navigateur interne et on passe le User-Agent à celui de Firefox avant de présenter le captcha. Le captcha sera alors résolu pour le UA Firefox et les cookies qui en résultent sont sauvegardés et utilisés par le reste de l'application. On restaure les cookies d'origine une fois la WebView fermée.

Le User-Agent par défaut de la WebView de l'émulateur semble poser problème à CloudFlare mais l'utilisation d'un User-Agent comme cURL ou wget fonctionne, ironiquement. Si le problème persiste, il faudra peut-être songer à utiliser un User-Agent moins discret (paradoxalement).