### PR TITLE
Correction système dabonnement regex (mise à jour du dom) (no bump)

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
@@ -25,7 +25,7 @@ public final class JVCParser {
     private static final Pattern ajaxModHashPattern = Pattern.compile("<input type=\"hidden\" name=\"ajax_hash_moderation_forum\" id=\"ajax_hash_moderation_forum\" value=\"([^\"]*)\" />");
     private static final Pattern ajaxPrefTimestampPattern = Pattern.compile("<input type=\"hidden\" name=\"ajax_timestamp_preference_user\" id=\"ajax_timestamp_preference_user\" value=\"([^\"]*)\" />");
     private static final Pattern ajaxPrefHashPattern = Pattern.compile("<input type=\"hidden\" name=\"ajax_hash_preference_user\" id=\"ajax_hash_preference_user\" value=\"([^\"]*)\" />");
-    private static final Pattern ajaxSubHashPattern = Pattern.compile("<body *data-abo-session=\"([^\"]*)\">");
+    private static final Pattern ajaxSubHashPattern = Pattern.compile("<body[^>]*data-abo-session=\"([^\"]*)\">");
     private static final Pattern messageQuotePattern = Pattern.compile("\"txt\":\"(.*)\"", Pattern.DOTALL);
     private static final Pattern entireMessagePattern = Pattern.compile("(<div class=\"bloc-message-forum[^\"]*\".*?)(<span id=\"post_[^\"]*\" class=\"bloc-message-forum-anchor\">|<div class=\"bloc-outils-plus-modo bloc-outils-bottom[^\"]*\">|<div class=\"bloc-pagi-default[^\"]*\">)", Pattern.DOTALL);
     private static final Pattern entireMessageInPermalinkPattern = Pattern.compile("(<div class=\"bloc-message-forum[^\"]*\".*?)(<div class=\"bloc-return-topic[^\"]*\">)", Pattern.DOTALL);


### PR DESCRIPTION
Le système d'abonnement sur les topics ne marchait plus. 
**Normalement :hap: ce fix est bon, mais il faut bumper la version.**  

https://github.com/FranckRJ/RespawnIRC-Android/blob/master/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java#L28

En fait cette regex n'est plus bonne, car JVC a attribué une classe à la balise body parce qu'ils ont déplacé le scope du CSS.
Et donc **ils ont modifié le HTML** pour attribuer une classe.

Avant : 
```<body data-abo-session="xxxxxxx"> ```
Maintenant
```<body class="jv-gaming" data-abo-session="xxxxxxx"> ```

Par conséquent, la valeur ne peut plus être récupérée avec l'ancienne regex

**Du coup j'en ai mis une nouvelle**  (Qui tient compte qu'un élément peut être présent dans` <body>`)
`ajaxSubHashPattern = Pattern.compile("<body[^>]*data-abo-session=\"([^\"]*)\">");`

Ça semble fonctionner à nouveau : 

<img width="267" height="50" alt="Screenshot_20251010_030709_RespawnIRC" src="https://github.com/user-attachments/assets/237eaed5-0402-48bd-a975-4e20de2d99a8" />
<img width="277" height="50" alt="Screenshot_20251010_030715_RespawnIRC" src="https://github.com/user-attachments/assets/bcef687a-dea8-411e-8f3e-4abeebfabf77" />

(J'ai fait le compile à l'arrache avec github action, car je ne connais pas trop Java.)
Il faut bumper la version. 

Bref c'est juste le DOM qui a changé au niveau de la balise body Rien de très farfelu pour une fois c'est simple..


