### PR TITLE
fix quote

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
@@ -889,7 +889,7 @@ public final class JVCParser {
     }
 
     public static String buildMessageQuoted(MessageInfos thisMessageInfo) {
-        return "> Le " + thisMessageInfo.wholeDate + " " + thisMessageInfo.pseudo + " a écrit:\n>"
+        return "> Le " + thisMessageInfo.wholeDate + " " + thisMessageInfo.pseudo + " a écrit :\n>"
                 + thisMessageInfo.messageRaw.replaceAll("\n", "\n>");
     }
 


### PR DESCRIPTION
@FranckRJ Bonjour je me permets de proposer cette PR parce que j'ai vu que l'espace sur la fin avait été mangé lors de la maj 

lors de ce commit https://github.com/FranckRJ/RespawnIRC-Android/commit/ed5290e80a8b93cd5975ab6c9d3043c18cb2b542

Alors je voulais savoir si c'était volontaire et j'ai écrit ce truc à la zobe.

Le souci c'est que ce Pattern "écrit:" sans espace peut parfois créer des conflits avec d'autres userscripts .

Comme ça a l'air d'être un bug de refactor et que c'est vraiment un tout petit changement je voulais savoir s'il y avait moyenne de revenir au format canonique en sachant que c'est juste un micro espace .
 
Merci à toi "Shiho"