### PR TITLE
Connexion : Pré-remplit le pseudo depuis la page une fois connecté.

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/ConnectActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/ConnectActivity.java
@@ -96,6 +96,7 @@ public class ConnectActivity extends AbsHomeIsBackActivity {
             public void onPageFinished(WebView view, String url) {
                 if (url.startsWith("https://www.jeuxvideo.com")) {
                     jvcWebView.evaluateJavascript("Didomi.setUserAgreeToAll();", null);
+                    tryToPrefillPseudoFromPage();
                 }
             }
         });
@@ -116,6 +117,29 @@ public class ConnectActivity extends AbsHomeIsBackActivity {
         PrefsManager.putInt(PrefsManager.IntPref.Names.NUMBER_OF_WEBVIEW_OPEN_SINCE_CACHE_CLEARED,
                 PrefsManager.getInt(PrefsManager.IntPref.Names.NUMBER_OF_WEBVIEW_OPEN_SINCE_CACHE_CLEARED) + 1);
         PrefsManager.applyChanges();
+    }
+
+    /* Une fois connecté sur JVC, le pseudo de l'utilisateur est présent dans l'en-tête de la page    */
+    /* (.headerAccount__pseudo). On le cible via le conteneur .headerAccount--user car déconnecté ce  */
+    /* même .headerAccount__pseudo contient le texte « CONNEXION » (conteneur .headerAccount--connect)*/
+    /* On pré-remplit le champ uniquement s'il est vide afin de ne pas écraser une saisie manuelle.   */
+    private void tryToPrefillPseudoFromPage() {
+        jvcWebView.evaluateJavascript(
+                "(function(){var el=document.querySelector('.headerAccount--user .headerAccount__pseudo');return el?el.textContent.trim():'';})()",
+                value -> {
+                    if (value == null || pseudoText == null || !pseudoText.getText().toString().isEmpty()) {
+                        return;
+                    }
+
+                    String pseudo = value.trim();
+                    if (pseudo.length() >= 2 && pseudo.startsWith("\"") && pseudo.endsWith("\"")) {
+                        pseudo = pseudo.substring(1, pseudo.length() - 1).replace("\\\"", "\"").replace("\\\\", "\\");
+                    }
+
+                    if (!pseudo.isEmpty()) {
+                        pseudoText.setText(pseudo);
+                    }
+                });
     }
 
     @Override


### PR DESCRIPTION
Récupère le pseudo dans l'en-tête de la WebView (.headerAccount--user .headerAccount__pseudo) via evaluateJavascript et pré-remplit le champ. Le conteneur .headerAccount--user évite de récupérer « CONNEXION » lorsque l'utilisateur est déconnecté.

On ne remplit le champ que s'il est vide, afin de ne pas écraser une saisie manuelle. Le champ manuel est conservé comme solution de repli au cas où ce pré-remplissage cesserait de fonctionner (notamment si JVC modifie la structure de la page).