### PR TITLE
Build : Désactive Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,9 @@ org.gradle.jvmargs=-Xmx1536m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+# C’est legacy, et Android Studio 2026.1 se plaignait que ce soit activé
+# car ça ralentit le build.
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.nonTransitiveRClass=false


### PR DESCRIPTION
Une balloon notification vient nous emmerder dans Android Studio pour nous indiquer que c’est mieux de désactiver Jetifier s’il y en a pas besoin afin d’améliorer le temps que ça met à build.

Rien n’utilise Jetifier, donc autant le désactiver pour calmer Android Studio et potentiellement améliorer légèrement le temps de build.

Messages d’Android Studio initial :
> Check if you need Jetifier in your project
>
> Your project’s gradle.properties file includes 'android.enableJetifier=true'. This flag is needed to enable AndroidX for libraries that don’t support it natively. Learn more .
>
> Removing Jetifier could reduce project build time. To disable Jetifier your project should have no dependencies on legacy support libraries. Run check to see if you have any of such dependencies in your project.

Message après check :
> This check found 0 declared dependencies that require Jetifier in your project. You can safely remove the 'android.enableJetifier' flag.

Explication de Claude Fable 5 :
> Jetifier itself is a relic of the 2018 migration from the old Support Libraries (`com.android.support.*`, frozen at 28.0.0) to AndroidX. Two flags were involved: `android.useAndroidX=true` makes your own code compile against the `androidx.*` packages, while `android.enableJetifier=true` handles the *third-party* problem — it's an artifact transform that scans every binary dependency (AARs/JARs) during resolution and rewrites bytecode still referencing the old support packages to point at AndroidX instead. That scan-and-rewrite costs time on every dependency, which is why it's pure dead weight once your dependency tree is fully AndroidX. […] So you did the right thing: drop `enableJetifier`, keep `useAndroidX=true`, enjoy slightly faster sync and dependency resolution.

Docu de Jetifier : https://developer.android.com/tools/jetifier