### PR TITLE
Build : Corrige deux dépréciations Gradle 9/10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,20 +21,20 @@ android {
         jvmTarget = '1.8'
     }
     buildFeatures {
-        viewBinding true
+        viewBinding = true
         dataBinding = true
     }
     buildTypes {
         release {
             minifyEnabled true
-            shrinkResources true
+            shrinkResources = true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         debug {
             applicationIdSuffix ".dev"
         }
     }
-    namespace 'com.franckrj.respawnirc'
+    namespace = 'com.franckrj.respawnirc'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '2.2.21'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.2'


### PR DESCRIPTION
## Enlève "jcenter" des dépôts de buildscript (pour Gradle 9)

Gradle 9 (sorti en juillet 2025) n’en veut plus : https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#removal_of_deprecated_jcenter

jcenter() n’était déjà plus qu’une redirection vers mavenCentral(). Maven héberge la dépendance buildscript `org.jetbrains.kotlin:kotlin-gradle-plugin`.

## Build : Utilise la syntaxe Groovy "propName = value" (pour Gradle 10)

Gradle 10 supprimera la syntaxe "space-assignment" (`propName value`), dépréciée depuis Gradle 8.12 : https://docs.gradle.org/9.5.1/userguide/upgrading_version_8.html#groovy_space_assignment_syntax

Seules les propriétés générées par Gradle déclenchaient l'avertissement : `viewBinding`, `shrinkResources` et `namespace`. Les autres entrées du DSL (celles de defaultConfig, `minifyEnabled`…) correspondent à de vraies méthodes et restent donc valides.