### PR TITLE
Build : Assainissement des règles ProGuard

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,25 +1,6 @@
+# Conserver les numéros de ligne pour pouvoir désobfusquer les stack traces des rapports
+# de crash en release (en masquant le nom de fichier source d'origine). À recroiser avec
+# le mapping.txt du build correspondant (build/outputs/mapping/) pour retrouver classes,
+# méthodes et lignes d'origine.
 -renamesourcefileattribute SourceFile
 -keepattributes SourceFile,LineNumberTable
-
-# Coroutine optimisation pour Dispatchers.Main, potentiellement plus nécessaire depuis AS 3.6.
--assumevalues class kotlinx.coroutines.internal.MainDispatcherLoader {
-  boolean FAST_SERVICE_LOADER_ENABLED return false;
-}
-# -checkdiscard class kotlinx.coroutines.internal.FastServiceLoader
-
-# OkHttp
--dontwarn javax.annotation.**
--dontwarn org.codehaus.mojo.animal_sniffer.*
--dontwarn okhttp3.internal.platform.ConscryptPlatform
--keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
-
-# Glide
--keep public class * implements com.bumptech.glide.module.GlideModule
--keep public class * extends com.bumptech.glide.module.AppGlideModule
--keep public enum com.bumptech.glide.load.ImageHeaderParser$** {
-  **[] $VALUES;
-  public *;
-}
-
-# Glide integration libraries
--keep class com.bumptech.glide.GeneratedAppGlideModuleImpl


### PR DESCRIPTION
Toutes les règles spécifiques aux bibliothèques étaient inutiles.

> Aucune règle spécifique aux bibliothèques n'a besoin d'être maintenue côté app. Selon les cas, elles faisaient doublon avec les consumer rules embarquées dans les AAR/JAR des dépendances (mergées par AGP), étaient devenues obsolètes (mécanisme changé en amont), ou n'ont en réalité jamais été nécessaires. Détail :
>     
> - Coroutines (bloc FastServiceLoader) : doublon. kotlinx-coroutines-android embarque une version plus complète en -assumenosideeffects, appliquée par R8 depuis AGP 3.6.
> - OkHttp (-dontwarn javax.annotation, animal_sniffer, ConscryptPlatform) : doublon, fournis par les consumer rules d'okhttp-android.
> - OkHttp (-keepnames PublicSuffixDatabase) : obsolète, relique d'OkHttp 4.x. Depuis OkHttp 5, sur Android, la liste des suffixes est chargée depuis les assets (AssetPublicSuffixList, chemin constant, contexte via l'initializer androidx.startup), non plus via une ressource du classpath dérivée du nom de classe ; les assets n'étant pas touchés par R8, la règle ne sert plus à rien.
> - Glide (GlideModule, AppGlideModule, ImageHeaderParser, GeneratedAppGlideModuleImpl) : jamais nécessaire. Tout est déjà couvert par les consumer rules de Glide ; en particulier GeneratedAppGlideModuleImpl (chargé par réflexion) est conservé, constructeur inclus, par la règle `-keep class * extends AppGlideModule { <init>(...); }` de Glide, qui matche transitivement (Impl -> GeneratedAppGlideModule -> AppGlideModule). Vérifié via le mapping/seeds R8 : sans notre règle, la classe et son constructeur (Context) restent conservés et non renommés.
>     
> Ne subsistent que les deux attributs relevant d'un choix de l'app (numéros de ligne conservés pour désobfusquer les stack traces). Vérifié par assembleRelease (R8 réexécuté, build OK).