### PR TITLE
Build : Augmentation du heap du démon Gradle à 2 Go

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,6 @@
-# Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+# Valeur de plafond de heap par défaut pour les nouveaux projets créés avec Android Studio 2026.
+org.gradle.jvmargs=-Xmx2048m
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
On s’aligne sur la valeur de 2 Go que met Android Studio 2026 pour les nouveaux projets. Devrait légèrement améliorer la performance des tâches du démon Gradle (résolution des dépendances, tâches AGP, R8) on imagine.

On supprime le blabla du template en commentaires au passage.

(Android Studio 2026 rajoute aussi `-Dfile.encoding=UTF-8` aux `jvmargs` mais c’est redondant car le démon Gradle est sous JDK 21 qui l’active par défaut.)