### PR TITLE
Désactivation de dataBinding pour les perfs de build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,6 @@ android {
     }
     buildFeatures {
         viewBinding = true
-        dataBinding = true
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/franckrj/respawnirc/dialogs/InsertStuffDialogFragment.kt
+++ b/app/src/main/java/com/franckrj/respawnirc/dialogs/InsertStuffDialogFragment.kt
@@ -453,7 +453,6 @@ class InsertStuffDialogFragment : DialogFragment() {
         val builder = AlertDialog.Builder(requireActivity())
 
         bindings = DialogInsertstuffBinding.inflate(requireActivity().layoutInflater)
-        bindings.dialog = this
 
         listOfCategoryButtons.add(bindings.smileyButtonInsertstuff)
         listOfCategoryButtons.add(bindings.textformatButtonInsertstuff)

--- a/app/src/main/res/layout/dialog_insertstuff.xml
+++ b/app/src/main/res/layout/dialog_insertstuff.xml
@@ -1,202 +1,190 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 
-    <data>
-
-        <variable
-            name="dialog"
-            type="com.franckrj.respawnirc.dialogs.InsertStuffDialogFragment" />
-
-    </data>
-
-    <RelativeLayout
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list_content_insertstuff"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent"
+        android:layout_alignParentStart="true"
+        android:layout_toStartOf="@+id/list_separator_insertstuff"
+        android:scrollbars="vertical" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/list_content_insertstuff"
+    <View
+        android:id="@+id/list_separator_insertstuff"
+        android:layout_width="2dp"
+        android:layout_height="match_parent"
+        android:layout_toStartOf="@+id/list_scrollview_insertstuff"
+        android:background="?attr/themedDarkerPopupBackgroundColor" />
+
+    <ScrollView
+        android:id="@+id/list_scrollview_insertstuff"
+        android:layout_width="60dp"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:scrollbars="vertical">
+
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_alignParentStart="true"
-            android:layout_toStartOf="@+id/list_separator_insertstuff"
-            android:scrollbars="vertical" />
-
-        <View
-            android:id="@+id/list_separator_insertstuff"
-            android:layout_width="2dp"
-            android:layout_height="match_parent"
-            android:layout_toStartOf="@+id/list_scrollview_insertstuff"
-            android:background="?attr/themedDarkerPopupBackgroundColor" />
-
-        <ScrollView
-            android:id="@+id/list_scrollview_insertstuff"
-            android:layout_width="60dp"
             android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:scrollbars="vertical">
+            android:orientation="vertical">
 
-            <LinearLayout
+            <ImageView
+                android:id="@+id/smiley_button_insertstuff"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/smiley_general" />
 
-                <ImageView
-                    android:id="@+id/smiley_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/smiley_general" />
+            <ImageView
+                android:id="@+id/textformat_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="?attr/themedTextFormatGeneral" />
 
-                <ImageView
-                    android:id="@+id/textformat_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="?attr/themedTextFormatGeneral" />
+            <ImageView
+                android:id="@+id/sticker_1_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_zuc" />
 
-                <ImageView
-                    android:id="@+id/sticker_1_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_zuc" />
+            <ImageView
+                android:id="@+id/sticker_2_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1jnd" />
 
-                <ImageView
-                    android:id="@+id/sticker_2_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1jnd" />
+            <ImageView
+                android:id="@+id/sticker_3_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1kgu" />
 
-                <ImageView
-                    android:id="@+id/sticker_3_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1kgu" />
+            <ImageView
+                android:id="@+id/sticker_4_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1kkh" />
 
-                <ImageView
-                    android:id="@+id/sticker_4_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1kkh" />
+            <ImageView
+                android:id="@+id/sticker_5_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1kkr" />
 
-                <ImageView
-                    android:id="@+id/sticker_5_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1kkr" />
+            <ImageView
+                android:id="@+id/sticker_6_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1kl6" />
 
-                <ImageView
-                    android:id="@+id/sticker_6_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1kl6" />
+            <ImageView
+                android:id="@+id/sticker_7_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1lgg" />
 
-                <ImageView
-                    android:id="@+id/sticker_7_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1lgg" />
+            <ImageView
+                android:id="@+id/sticker_8_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1ljl" />
 
-                <ImageView
-                    android:id="@+id/sticker_8_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1ljl" />
+            <ImageView
+                android:id="@+id/sticker_9_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1lm9" />
 
-                <ImageView
-                    android:id="@+id/sticker_9_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1lm9" />
+            <ImageView
+                android:id="@+id/sticker_10_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1nub" />
 
-                <ImageView
-                    android:id="@+id/sticker_10_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1nub" />
+            <ImageView
+                android:id="@+id/sticker_11_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1ltd" />
 
-                <ImageView
-                    android:id="@+id/sticker_11_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1ltd" />
+            <ImageView
+                android:id="@+id/sticker_12_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1n1p" />
 
-                <ImageView
-                    android:id="@+id/sticker_12_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1n1p" />
+            <ImageView
+                android:id="@+id/sticker_13_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1n2c" />
 
-                <ImageView
-                    android:id="@+id/sticker_13_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1n2c" />
+            <ImageView
+                android:id="@+id/sticker_14_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1o33" />
 
-                <ImageView
-                    android:id="@+id/sticker_14_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1o33" />
+            <ImageView
+                android:id="@+id/sticker_15_button_insertstuff"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:contentDescription="@string/insertStuff"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/sticker_1ptd" />
 
-                <ImageView
-                    android:id="@+id/sticker_15_button_insertstuff"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:contentDescription="@string/insertStuff"
-                    android:padding="8dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/sticker_1ptd" />
+        </LinearLayout>
 
-            </LinearLayout>
+    </ScrollView>
 
-        </ScrollView>
-
-    </RelativeLayout>
-
-</layout>
+</RelativeLayout>


### PR DESCRIPTION
> dataBinding n'était quasiment pas utilisé : seul dialog_insertstuff.xml avait une enveloppe <layout>, avec une variable dialog jamais consommée par une expression @{} (l'affectation bindings.dialog = this était donc morte). viewBinding génère déjà la même classe DialogInsertstuffBinding dans le même package, donc le Kotlin compile à l'identique.
> 
> Désactiver dataBinding retire son annotation processor de la compilation (il s'appliquait à tout le module), **ce qui allège et accélère les builds propres**.
> 
> Le gros du diff de dialog_insertstuff.xml n'est que de la réindentation suite au retrait du niveau <layout> ; à relire avec git show -w.