### PR TITLE
Build : Suppression de flags AndroidX inutiles

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,14 +11,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app's APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-# C’est legacy, et Android Studio 2026.1 se plaignait que ce soit activé
-# car ça ralentit le build.
-android.enableJetifier=false
+
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.nonTransitiveRClass=false


### PR DESCRIPTION
Utiliser AndroidX est activé par défaut avec AGP 9. Jetifier est legacy des débuts d’AndroidX.

AGP 10 ne permettra même plus de changer ces flags.

Source : https://developer.android.com/jetpack/androidx#using_androidx_libraries_in_your_project