### PR TITLE
Build : Màj Gradle 9.6.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Changement suggéré par Android Studio.

Idéalement il faudrait aussi mettre à jour le wrapper (comme dans #45), avec cette commande des [release notes section « Upgrade instructions »](https://docs.gradle.org/current/release-notes.html#upgrade-instructions) :  `./gradlew :wrapper --gradle-version=9.6.0 && ./gradlew :wrapper`