### PR TITLE
Build : petite retouche de gradle.settings

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
+
+rootProject.name = "RespawnIRC"
 include ':app'
-rootProject.name='RespawnIRC'


### PR DESCRIPTION
- Met des espaces autour du signe égal après root.projectName
- Inverse l’ordre des directives include et rootProject.name et ajoute un saut de ligne avant, pour s’aligner sur le template d’un nouveau projet Android Studio (ainsi que `gradle init`) et être plus logique (qu’est-ce, puis qu’est-ce qu’il y a dedans ; pour `plugins` Gradle le veut forcément avant)