### PR TITLE
Build : Suppression du bloc commenté org.gradle.parallel.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,6 @@
 # Valeur de plafond de heap par défaut pour les nouveaux projets créés avec Android Studio 2026.
 org.gradle.jvmargs=-Xmx2048m
 
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.nonTransitiveRClass=false


### PR DESCRIPTION
> Cette option ne parallélise que les builds multi-modules ; comme le projet n'a qu'un seul module (:app), elle n'aurait aucun effet. Le bloc, généré par défaut par Android Studio, n'est que du bruit et n'a quasiment aucune chance d'être un jour utile sur un projet aussi petit.