### PR TITLE
Build : Suppression de android.r8.strictFullModeForKeepRules=false.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,3 @@ org.gradle.jvmargs=-Xmx2048m
 kotlin.code.style=official
 android.nonTransitiveRClass=false
 org.gradle.configuration-cache=true
-android.r8.strictFullModeForKeepRules=false


### PR DESCRIPTION
Un truc de [R8](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization) dont on se fout éperdument qui a changé avec AGP 8. Claude a vérifié les logs R8 avant/après pour s’assurer qu’on puisse le retirer sans incidence.

> Le mode strict des règles keep de R8 est le défaut (true) depuis AGP 8 ; ce flag, ajouté par l'assistant de migration AGP, forçait l'ancien comportement non strict. Vérifié comme sans effet sur l'artefact via un build différentiel.
> 
> Méthode : deux ./gradlew :app:assembleRelease --rerun-tasks, l'un avec le flag (strict=false), l'autre sans (strict=true par défaut), puis comparaison des sorties R8 dans app/build/outputs/mapping/release.
> 
> Résultats :
> - usage.txt (code retiré par R8) : identique.
> - configuration.txt (règles fusionnées appliquées par R8) : identique.
> - mapping.txt (renommage d'obfuscation) : identique au niveau ensemble ; les ~229 lignes de diff brut n'étaient que du réordonnancement, le set des classes renommées est rigoureusement le même (0 différence).
> - seeds.txt : seule vraie différence, 3 constructeurs androidx (RemoteActionCompat, IconCompat, CustomVersionedParcelable) perdent leur statut de seed, mais ces classes restent conservées et non renommées dans les deux cas (comptes usage.txt identiques) — simple bookkeeping, sans impact sur la sortie.
> 
> La sortie R8 étant fonctionnellement identique avec et sans le flag, et le build de release actuel fonctionnant, ce flag de compat n'a plus d'utilité.