### PR TITLE
AsyncTask…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,11 +30,17 @@ android {
         }
     }
     namespace = 'com.franckrj.respawnirc'
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.16.1'
     androidTestImplementation 'androidx.test:runner:1.7.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
     implementation 'androidx.activity:activity-ktx:1.10.1'

--- a/app/src/main/java/com/franckrj/respawnirc/base/AbsAsyncTask.java
+++ b/app/src/main/java/com/franckrj/respawnirc/base/AbsAsyncTask.java
@@ -1,0 +1,236 @@
+package com.franckrj.respawnirc.base;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+import androidx.annotation.WorkerThread;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Remplacement maison de android.os.AsyncTask, déprécié depuis Android 11.
+ *
+ * L'API publique reproduit volontairement celle d'AsyncTask (execute / executeOnExecutor /
+ * cancel / isCancelled / getStatus / publishProgress ainsi que les callbacks onPreExecute /
+ * doInBackground / onProgressUpdate / onPostExecute / onCancelled) afin de limiter au maximum
+ * l'impact sur les classes existantes.
+ *
+ * Le travail s'exécute sur un Executor (par défaut un exécuteur série, comme AsyncTask.execute)
+ * et les callbacks de cycle de vie sont délivrés sur le thread principal.
+ */
+public abstract class AbsAsyncTask<Params, Progress, Result> {
+    public enum Status {
+        PENDING,
+        RUNNING,
+        FINISHED
+    }
+
+    private static final int CPU_COUNT = Runtime.getRuntime().availableProcessors();
+    private static final int CORE_POOL_SIZE = Math.max(2, Math.min(CPU_COUNT - 1, 4));
+    private static final int MAXIMUM_POOL_SIZE = CPU_COUNT * 2 + 1;
+    private static final int KEEP_ALIVE_SECONDS = 30;
+
+    private static final ThreadFactory THREAD_FACTORY = new ThreadFactory() {
+        private final AtomicInteger count = new AtomicInteger(1);
+
+        @Override
+        public Thread newThread(@NonNull Runnable runnable) {
+            return new Thread(runnable, "AbsAsyncTask #" + count.getAndIncrement());
+        }
+    };
+
+    /**
+     * Équivalent de AsyncTask.THREAD_POOL_EXECUTOR : exécution en parallèle.
+     * <p>
+     * <b>Attention</b> : comme AsyncTask, la file d'attente est bornée (128). Si plus de
+     * MAXIMUM_POOL_SIZE + 128 tâches sont en vol simultanément, execute() lèvera une
+     * RejectedExecutionException. Ça n'arrive pas avec les usages actuels (le chemin par défaut
+     * passe par SERIAL_EXECUTOR qui ne soumet qu'une tâche à la fois, et ImageDownloader limite
+     * lui-même à 8 téléchargements concurrents) ; à garder en tête si on soumet un jour de gros
+     * volumes directement sur ce pool.
+     */
+    public static final Executor THREAD_POOL_EXECUTOR;
+
+    static {
+        ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
+                CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE_SECONDS, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(128), THREAD_FACTORY);
+        threadPoolExecutor.allowCoreThreadTimeOut(true);
+        THREAD_POOL_EXECUTOR = threadPoolExecutor;
+    }
+
+    /** Équivalent de AsyncTask.SERIAL_EXECUTOR : exécution séquentielle, utilisé par défaut. */
+    private static final Executor SERIAL_EXECUTOR = new SerialExecutor();
+
+    private static Handler mainHandlerInstance = null;
+
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+    private volatile Status status = Status.PENDING;
+
+    // Permet d'injecter un exécuteur de thread principal synchrone pour les tests.
+    private Executor mainThreadExecutor = null;
+
+    /*
+     * Callbacks du cycle de vie (patron de méthode, comme android.os.AsyncTask). Ils sont
+     * appelés par la mécanique de cette classe (execute / publishProgress / finish) et sont
+     * destinés à être surchargés par les sous-classes : doInBackground est obligatoire, les
+     * autres ont une implémentation vide par défaut pour ne surcharger que ce dont on a besoin.
+     * Ils paraissent inutilisés ici mais ils le sont depuis l'extérieur :
+     *   - onPreExecute      : surchargé par AbsWebRequestAsyncTask ;
+     *   - onPostExecute     : surchargé par AbsWebRequestAsyncTask et ImageGetterAsyncTask ;
+     *   - onProgressUpdate  : surchargé par ImageGetterAsyncTask ;
+     *   - onCancelled       : point d'extension pour un nettoyage à l'annulation (aucune
+     *                         sous-classe ne l'utilise pour l'instant, conservé par parité
+     *                         avec AsyncTask et exercé par les tests).
+     */
+
+    // @SuppressWarnings("unchecked") : « heap pollution » inhérente aux varargs de type
+    // générique (Params...). @SafeVarargs serait l'annotation idéale mais le langage l'interdit
+    // sur une méthode surchargeable (abstraite ici). L'usage est sûr : on ne fait que lire le
+    // tableau reçu, jamais y écrire ni l'exposer.
+    @WorkerThread
+    @SuppressWarnings("unchecked")
+    protected abstract Result doInBackground(Params... params);
+
+    @MainThread
+    protected void onPreExecute() {
+    }
+
+    @MainThread
+    protected void onPostExecute(Result result) {
+    }
+
+    // Voir doInBackground pour l'explication de @SuppressWarnings("unchecked").
+    @MainThread
+    @SuppressWarnings("unchecked")
+    protected void onProgressUpdate(Progress... values) {
+    }
+
+    @MainThread
+    protected void onCancelled(Result result) {
+    }
+
+    public final Status getStatus() {
+        return status;
+    }
+
+    public final boolean isCancelled() {
+        return cancelled.get();
+    }
+
+    /**
+     * Annulation <b>coopérative</b> : positionne simplement un drapeau que doInBackground doit
+     * consulter via {@link #isCancelled()} (et que WebManager surveille via le Callable passé à
+     * initWebInfos). Une fois la tâche annulée, finish() appelle onCancelled() au lieu de
+     * onPostExecute().
+     * <p>
+     * Contrairement à android.os.AsyncTask, il n'y a volontairement pas de paramètre
+     * {@code mayInterruptIfRunning} : le thread de fond n'est jamais interrompu, donc on ne propose
+     * pas une option qu'on ignorerait (passer {@code true} deviendrait silencieusement faux). Si une
+     * vraie interruption devient nécessaire un jour, il faudra conserver le Future renvoyé par
+     * l'Executor dans executeOnExecutor() et l'annuler ici.
+     */
+    public final void cancel() {
+        cancelled.set(true);
+    }
+
+    @MainThread
+    @SafeVarargs
+    public final AbsAsyncTask<Params, Progress, Result> execute(Params... params) {
+        return executeOnExecutor(SERIAL_EXECUTOR, params);
+    }
+
+    @MainThread
+    @SafeVarargs
+    public final AbsAsyncTask<Params, Progress, Result> executeOnExecutor(Executor executor, Params... params) {
+        if (status != Status.PENDING) {
+            throw new IllegalStateException("Cannot execute task: the task is already " +
+                    (status == Status.RUNNING ? "running." : "finished."));
+        }
+        status = Status.RUNNING;
+        onPreExecute();
+        executor.execute(() -> {
+            final Result result = doInBackground(params);
+            postToMainThread(() -> finish(result));
+        });
+        return this;
+    }
+
+    @WorkerThread
+    @SafeVarargs
+    protected final void publishProgress(Progress... values) {
+        if (!isCancelled()) {
+            postToMainThread(() -> onProgressUpdate(values));
+        }
+    }
+
+    @MainThread
+    private void finish(Result result) {
+        if (isCancelled()) {
+            onCancelled(result);
+        } else {
+            onPostExecute(result);
+        }
+        status = Status.FINISHED;
+    }
+
+    private void postToMainThread(Runnable action) {
+        if (mainThreadExecutor != null) {
+            mainThreadExecutor.execute(action);
+        } else {
+            getMainHandler().post(action);
+        }
+    }
+
+    private static synchronized Handler getMainHandler() {
+        if (mainHandlerInstance == null) {
+            mainHandlerInstance = new Handler(Looper.getMainLooper());
+        }
+        return mainHandlerInstance;
+    }
+
+    @VisibleForTesting
+    void setMainThreadExecutorForTesting(Executor newMainThreadExecutor) {
+        mainThreadExecutor = newMainThreadExecutor;
+    }
+
+    /**
+     * Exécuteur série : enchaîne les tâches une à une sur le pool de threads,
+     * comme le faisait l'exécuteur par défaut d'AsyncTask.
+     */
+    @VisibleForTesting
+    static final class SerialExecutor implements Executor {
+        private final ArrayDeque<Runnable> tasks = new ArrayDeque<>();
+        private Runnable active = null;
+
+        @Override
+        public synchronized void execute(@NonNull final Runnable runnable) {
+            tasks.offer(() -> {
+                try {
+                    runnable.run();
+                } finally {
+                    scheduleNext();
+                }
+            });
+            if (active == null) {
+                scheduleNext();
+            }
+        }
+
+        private synchronized void scheduleNext() {
+            if ((active = tasks.poll()) != null) {
+                THREAD_POOL_EXECUTOR.execute(active);
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/franckrj/respawnirc/base/AbsWebRequestAsyncTask.java
+++ b/app/src/main/java/com/franckrj/respawnirc/base/AbsWebRequestAsyncTask.java
@@ -1,12 +1,10 @@
 package com.franckrj.respawnirc.base;
 
-import android.os.AsyncTask;
-
 import com.franckrj.respawnirc.utils.WebManager;
 
 import java.util.concurrent.Callable;
 
-public abstract class AbsWebRequestAsyncTask<Params, Progress, Result> extends AsyncTask<Params, Progress, Result> {
+public abstract class AbsWebRequestAsyncTask<Params, Progress, Result> extends AbsAsyncTask<Params, Progress, Result> {
     private RequestIsFinished<Result> requestIsFinishedListener = null;
     private RequestIsStarted requestIsStartedListener = null;
 
@@ -21,7 +19,7 @@ public abstract class AbsWebRequestAsyncTask<Params, Progress, Result> extends A
     public void clearListenersAndCancel() {
         requestIsStartedListener = null;
         requestIsFinishedListener = null;
-        cancel(false);
+        cancel();
     }
 
     protected WebManager.WebInfos initWebInfos(String newCookiesInAString, boolean newFollowRedirects) {

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicgetters/JVCTopicModeIRCGetter.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicgetters/JVCTopicModeIRCGetter.java
@@ -1,9 +1,9 @@
 package com.franckrj.respawnirc.jvctopic.jvctopicgetters;
 
 import android.app.Activity;
-import android.os.AsyncTask;
 import android.os.Bundle;
 
+import com.franckrj.respawnirc.base.AbsAsyncTask;
 import com.franckrj.respawnirc.base.AbsWebRequestAsyncTask;
 import com.franckrj.respawnirc.utils.JVCParser;
 import com.franckrj.respawnirc.utils.ParcelableLongSparseStringArray;
@@ -160,7 +160,7 @@ public class JVCTopicModeIRCGetter extends AbsJVCTopicGetter {
     @Override
     public boolean reloadTopic(boolean useBiggerTimeoutTime) {
         if (currentAsyncTaskForGetMessage != null) {
-            if (!currentAsyncTaskForGetMessage.getStatus().equals(AsyncTask.Status.RUNNING)) {
+            if (!currentAsyncTaskForGetMessage.getStatus().equals(AbsAsyncTask.Status.RUNNING)) {
                 timerForFetchUrl.cancel();
                 timerForFetchUrl = new Timer();
                 stopAllCurrentTask();
@@ -200,7 +200,7 @@ public class JVCTopicModeIRCGetter extends AbsJVCTopicGetter {
                 @Override
                 public void run() {
                     if (currentAsyncTaskForGetMessage != null) {
-                        if (currentAsyncTaskForGetMessage.getStatus().equals(AsyncTask.Status.PENDING)) {
+                        if (currentAsyncTaskForGetMessage.getStatus().equals(AbsAsyncTask.Status.PENDING)) {
                             currentAsyncTaskForGetMessage.setRequestIsStartedListener(getMessagesIsStartedListener);
                             currentAsyncTaskForGetMessage.setRequestIsFinishedListener(getMessagesIsFinishedListener);
                             currentAsyncTaskForGetMessage.execute(urlForTopicPage, cookieListInAString);

--- a/app/src/main/java/com/franckrj/respawnirc/utils/ImageDownloader.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/ImageDownloader.java
@@ -6,9 +6,10 @@ import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.InsetDrawable;
-import android.os.AsyncTask;
 
 import androidx.collection.SimpleArrayMap;
+
+import com.franckrj.respawnirc.base.AbsAsyncTask;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -153,7 +154,7 @@ public class ImageDownloader implements ImageGetterAsyncTask.RequestStatusChange
         listOfPendingsTasksInfos.clear();
         for (ImageGetterAsyncTask taskIterator : listOfCurrentsTasks) {
             taskIterator.setRequestStatusChangedListener(null);
-            taskIterator.cancel(false);
+            taskIterator.cancel();
         }
         listOfCurrentsTasks.clear();
     }
@@ -181,7 +182,7 @@ public class ImageDownloader implements ImageGetterAsyncTask.RequestStatusChange
                                                                         infosForDownload.scaleToSize, infosForDownload.setToDefaultAspectRatio);
         getterForImage.setRequestStatusChangedListener(this);
         listOfCurrentsTasks.add(getterForImage);
-        getterForImage.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        getterForImage.executeOnExecutor(AbsAsyncTask.THREAD_POOL_EXECUTOR);
     }
 
     private void downloadOfAFileEnded(ImageGetterAsyncTask taskEnded) {

--- a/app/src/main/java/com/franckrj/respawnirc/utils/ImageGetterAsyncTask.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/ImageGetterAsyncTask.java
@@ -2,7 +2,7 @@ package com.franckrj.respawnirc.utils;
 
 import static com.franckrj.respawnirc.utils.WebManager.userAgentString;
 
-import android.os.AsyncTask;
+import com.franckrj.respawnirc.base.AbsAsyncTask;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -12,7 +12,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-public class ImageGetterAsyncTask extends AsyncTask<Void, Long, String> {
+public class ImageGetterAsyncTask extends AbsAsyncTask<Void, Long, String> {
     private final DrawableWrapper wrapperForDrawable;
     private final String fileDownloadPath;
     private final String fileLocalPath;

--- a/app/src/test/java/com/franckrj/respawnirc/base/AbsAsyncTaskMainThreadDeliveryTest.java
+++ b/app/src/test/java/com/franckrj/respawnirc/base/AbsAsyncTaskMainThreadDeliveryTest.java
@@ -1,0 +1,106 @@
+package com.franckrj.respawnirc.base;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.os.Looper;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+/**
+ * Tests du chemin de livraison réel sur le thread principal (via Handler / Looper Android), que
+ * les tests JVM purs ne peuvent pas exercer faute de vrai Looper. Robolectric en fournit un qu'on
+ * fait avancer manuellement avec shadowOf(getMainLooper()).idle().
+ *
+ * Le travail de fond tourne en ligne (exécuteur direct) pour rester déterministe ; ce qu'on vérifie
+ * ici, c'est que le résultat est posté sur le Looper principal puis délivré quand celui-ci tourne —
+ * et qu'une annulation (cas de la rotation pendant un chargement) court-circuite la livraison.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AbsAsyncTaskMainThreadDeliveryTest {
+    private static final Executor DIRECT_EXECUTOR = Runnable::run;
+
+    private static boolean onMainThread() {
+        return Looper.myLooper() == Looper.getMainLooper();
+    }
+
+    private static class RecordingTask extends AbsAsyncTask<String, Void, String> {
+        final List<String> events = new ArrayList<>();
+
+        @Override
+        protected String doInBackground(String... params) {
+            events.add("background");
+            return "ok";
+        }
+
+        @Override
+        protected void onPostExecute(String result) {
+            events.add("post:" + result + "@" + (onMainThread() ? "main" : "bg"));
+        }
+
+        @Override
+        protected void onCancelled(String result) {
+            events.add("cancelled@" + (onMainThread() ? "main" : "bg"));
+        }
+    }
+
+    @Test
+    public void onPostExecute_isPostedToMainLooper_andDeliveredWhenItRuns() {
+        RecordingTask task = new RecordingTask();
+
+        task.executeOnExecutor(DIRECT_EXECUTOR, "x");
+
+        // Le résultat est posté sur le Looper principal mais pas encore délivré tant qu'il ne tourne pas.
+        assertEquals(List.of("background"), task.events);
+        assertEquals(AbsAsyncTask.Status.RUNNING, task.getStatus());
+
+        // On fait tourner le Looper principal : finish() -> onPostExecute s'exécute, sur le thread principal.
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertEquals(List.of("background", "post:ok@main"), task.events);
+        assertEquals(AbsAsyncTask.Status.FINISHED, task.getStatus());
+    }
+
+    @Test
+    public void cancelBeforeLooperRuns_routesToOnCancelledInsteadOfOnPostExecute() {
+        RecordingTask task = new RecordingTask();
+
+        task.executeOnExecutor(DIRECT_EXECUTOR, "x");
+        // Annulation alors que la livraison est encore en file d'attente sur le Looper principal.
+        task.cancel();
+
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertEquals(List.of("background", "cancelled@main"), task.events);
+    }
+
+    @Test
+    public void clearListenersAndCancel_beforeDelivery_dropsResult() {
+        // Modélise une rotation pendant un chargement web : la requête est en vol, l'activité est
+        // détruite (clearListenersAndCancel), puis le résultat arrive sur le Looper principal.
+        final List<String> received = new ArrayList<>();
+        AbsWebRequestAsyncTask<String, Void, String> task = new AbsWebRequestAsyncTask<String, Void, String>() {
+            @Override
+            protected String doInBackground(String... params) {
+                return "result";
+            }
+        };
+        task.setRequestIsFinishedListener(received::add);
+
+        task.executeOnExecutor(DIRECT_EXECUTOR, "url");
+        // Rotation : on coupe les listeners et on annule avant que le Looper ne délivre.
+        task.clearListenersAndCancel();
+
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertTrue("Aucun résultat ne doit être livré après clearListenersAndCancel().", received.isEmpty());
+        assertTrue(task.isCancelled());
+    }
+}

--- a/app/src/test/java/com/franckrj/respawnirc/base/AbsAsyncTaskTest.java
+++ b/app/src/test/java/com/franckrj/respawnirc/base/AbsAsyncTaskTest.java
@@ -1,0 +1,115 @@
+package com.franckrj.respawnirc.base;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+/**
+ * Vérifie le cycle de vie du remplacement d'AsyncTask.
+ *
+ * On injecte des exécuteurs synchrones (le travail de fond et le « thread principal » s'exécutent
+ * en ligne) pour rendre les tests déterministes, sans dépendre d'un Looper Android.
+ */
+public class AbsAsyncTaskTest {
+    private static final Executor DIRECT_EXECUTOR = Runnable::run;
+
+    /** Tâche de test qui journalise chaque étape de son cycle de vie. */
+    private static class RecordingTask extends AbsAsyncTask<String, Integer, String> {
+        final List<String> events = new ArrayList<>();
+        String[] receivedParams = null;
+        boolean throwInBackground = false;
+
+        RecordingTask() {
+            setMainThreadExecutorForTesting(DIRECT_EXECUTOR);
+        }
+
+        @Override
+        protected void onPreExecute() {
+            events.add("pre");
+        }
+
+        @Override
+        protected String doInBackground(String... params) {
+            receivedParams = params;
+            events.add("background");
+            publishProgress(1, 2);
+            return "result:" + (params.length > 0 ? params[0] : "");
+        }
+
+        @Override
+        protected void onProgressUpdate(Integer... values) {
+            events.add("progress:" + values.length);
+        }
+
+        @Override
+        protected void onPostExecute(String result) {
+            events.add("post:" + result);
+        }
+
+        @Override
+        protected void onCancelled(String result) {
+            events.add("cancelled:" + result);
+        }
+    }
+
+    private static RecordingTask runSynchronously(RecordingTask task, String... params) {
+        task.executeOnExecutor(DIRECT_EXECUTOR, params);
+        return task;
+    }
+
+    @Test
+    public void execute_runsFullLifecycleInOrder() {
+        RecordingTask task = runSynchronously(new RecordingTask(), "abc");
+
+        assertEquals(
+                List.of("pre", "background", "progress:2", "post:result:abc"),
+                task.events);
+        assertArrayEquals(new String[]{"abc"}, task.receivedParams);
+    }
+
+    @Test
+    public void status_progressesFromPendingToFinished() {
+        RecordingTask task = new RecordingTask();
+        assertEquals(AbsAsyncTask.Status.PENDING, task.getStatus());
+
+        runSynchronously(task, "x");
+        assertEquals(AbsAsyncTask.Status.FINISHED, task.getStatus());
+    }
+
+    @Test
+    public void cancelBeforeExecute_skipsPostAndCallsOnCancelled() {
+        RecordingTask task = new RecordingTask();
+        task.cancel();
+
+        runSynchronously(task, "y");
+
+        assertTrue(task.isCancelled());
+        // Pas de progression ni de onPostExecute quand la tâche est annulée.
+        assertEquals(List.of("pre", "background", "cancelled:result:y"), task.events);
+    }
+
+    @Test
+    public void isCancelled_isFalseByDefault() {
+        assertFalse(new RecordingTask().isCancelled());
+    }
+
+    @Test
+    public void executeTwice_throwsIllegalState() {
+        RecordingTask task = runSynchronously(new RecordingTask(), "once");
+
+        try {
+            task.executeOnExecutor(DIRECT_EXECUTOR);
+            fail("Une seconde exécution aurait dû lever IllegalStateException.");
+        } catch (IllegalStateException expected) {
+            // Comportement attendu.
+        }
+    }
+}

--- a/app/src/test/java/com/franckrj/respawnirc/base/SerialExecutorTest.java
+++ b/app/src/test/java/com/franckrj/respawnirc/base/SerialExecutorTest.java
@@ -1,0 +1,111 @@
+package com.franckrj.respawnirc.base;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Stress test de l'exécuteur série maison (équivalent de AsyncTask.SERIAL_EXECUTOR).
+ *
+ * L'exécuteur s'appuie sur un pool de threads parallèle ; on vérifie ici les deux garanties
+ * qu'il doit apporter par-dessus ce pool :
+ *   - exclusion mutuelle : jamais deux tâches en même temps ;
+ *   - ordre FIFO pour les soumissions issues d'un même thread.
+ *
+ * Ce test est du Java pur (aucune dépendance Android), il exerce donc le vrai multithreading.
+ */
+public class SerialExecutorTest {
+    @Test
+    public void runsTasksOneAtATime_underConcurrentSubmission() throws InterruptedException {
+        final int producerCount = 8;
+        final int tasksPerProducer = 200;
+        final int totalTasks = producerCount * tasksPerProducer;
+
+        AbsAsyncTask.SerialExecutor executor = new AbsAsyncTask.SerialExecutor();
+
+        final AtomicInteger currentlyRunning = new AtomicInteger(0);
+        final AtomicInteger maxObservedConcurrency = new AtomicInteger(0);
+        final AtomicInteger completedTasks = new AtomicInteger(0);
+        final CountDownLatch allDone = new CountDownLatch(totalTasks);
+
+        final Runnable task = () -> {
+            int running = currentlyRunning.incrementAndGet();
+            maxObservedConcurrency.accumulateAndGet(running, Math::max);
+            // Petite fenêtre pour rendre détectable une exécution concurrente si elle se produisait.
+            try {
+                Thread.sleep(0, 100_000);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            currentlyRunning.decrementAndGet();
+            completedTasks.incrementAndGet();
+            allDone.countDown();
+        };
+
+        // Plusieurs threads soumettent en même temps pour stresser la synchronisation de l'exécuteur.
+        final CountDownLatch startGun = new CountDownLatch(1);
+        final List<Thread> producers = new ArrayList<>();
+        for (int p = 0; p < producerCount; ++p) {
+            Thread producer = new Thread(() -> {
+                try {
+                    startGun.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                for (int i = 0; i < tasksPerProducer; ++i) {
+                    executor.execute(task);
+                }
+            });
+            producer.start();
+            producers.add(producer);
+        }
+
+        startGun.countDown();
+        for (Thread producer : producers) {
+            producer.join();
+        }
+
+        assertTrue("Toutes les tâches auraient dû se terminer dans le délai imparti.",
+                allDone.await(30, TimeUnit.SECONDS));
+        assertEquals("Chaque tâche soumise doit s'exécuter exactement une fois.",
+                totalTasks, completedTasks.get());
+        assertEquals("L'exécuteur série ne doit jamais exécuter deux tâches simultanément.",
+                1, maxObservedConcurrency.get());
+    }
+
+    @Test
+    public void preservesSubmissionOrderFromSingleThread() throws InterruptedException {
+        final int taskCount = 1000;
+        AbsAsyncTask.SerialExecutor executor = new AbsAsyncTask.SerialExecutor();
+
+        final List<Integer> executionOrder = Collections.synchronizedList(new ArrayList<>(taskCount));
+        final CountDownLatch allDone = new CountDownLatch(taskCount);
+
+        for (int i = 0; i < taskCount; ++i) {
+            final int index = i;
+            executor.execute(() -> {
+                executionOrder.add(index);
+                allDone.countDown();
+            });
+        }
+
+        assertTrue("Toutes les tâches auraient dû se terminer dans le délai imparti.",
+                allDone.await(30, TimeUnit.SECONDS));
+
+        final List<Integer> expectedOrder = new ArrayList<>(taskCount);
+        for (int i = 0; i < taskCount; ++i) {
+            expectedOrder.add(i);
+        }
+        assertEquals("Les tâches soumises depuis un seul thread doivent s'exécuter dans l'ordre (FIFO).",
+                expectedOrder, executionOrder);
+    }
+}

--- a/app/src/test/java/com/franckrj/respawnirc/utils/ImageGetterAsyncTaskTest.java
+++ b/app/src/test/java/com/franckrj/respawnirc/utils/ImageGetterAsyncTaskTest.java
@@ -1,0 +1,93 @@
+package com.franckrj.respawnirc.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.graphics.drawable.ColorDrawable;
+import android.os.Looper;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+/**
+ * Couvre le chemin « image » (parallèle), différent du chemin « topic » sur un seul point :
+ * la progression (publishProgress / onProgressUpdate), que les tâches web n'utilisent pas. On
+ * vérifie via le vrai Looper que progression et fin sont transmises au RequestStatusChanged sur le
+ * thread principal, et qu'un teardown façon ImageDownloader.stopAllCurrentTasks() (listener coupé +
+ * cancel) avant que le Looper ne tourne abandonne la livraison.
+ *
+ * doInBackground est stubbé (pas de réseau ni de fichier) ; on teste le câblage des callbacks, pas
+ * le téléchargement réel.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ImageGetterAsyncTaskTest {
+    private static final Executor DIRECT_EXECUTOR = Runnable::run;
+
+    private static String threadTag() {
+        return Looper.myLooper() == Looper.getMainLooper() ? "main" : "bg";
+    }
+
+    private static class RecordingListener implements ImageGetterAsyncTask.RequestStatusChanged {
+        final List<String> events = new ArrayList<>();
+
+        @Override
+        public void onRequestProgress(Long currentProgressInPercent, Long fileSize, ImageGetterAsyncTask task) {
+            events.add("progress:" + currentProgressInPercent + "/" + fileSize + "@" + threadTag());
+        }
+
+        @Override
+        public void onRequestFinished(String resultFileName, ImageGetterAsyncTask task) {
+            events.add("finished:" + resultFileName + "@" + threadTag());
+        }
+    }
+
+    /** Tâche dont le doInBackground est stubbé : publie une progression puis renvoie un chemin, sans réseau. */
+    private static ImageGetterAsyncTask newStubTask(final String resultPath) {
+        DrawableWrapper wrapper = new DrawableWrapper(new ColorDrawable());
+        return new ImageGetterAsyncTask(wrapper, "http://example.test/img.png", "/cache", true, false, false, false) {
+            @Override
+            protected String doInBackground(Void... params) {
+                publishProgress(50L, 1000L);
+                return resultPath;
+            }
+        };
+    }
+
+    @Test
+    public void progressAndFinish_areForwardedOnMainLooper() {
+        RecordingListener listener = new RecordingListener();
+        ImageGetterAsyncTask task = newStubTask("/cache/img.png");
+        task.setRequestStatusChangedListener(listener);
+
+        task.executeOnExecutor(DIRECT_EXECUTOR);
+
+        // Tout est posté sur le Looper principal mais rien n'est délivré tant qu'il ne tourne pas.
+        assertTrue(listener.events.isEmpty());
+
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertEquals(List.of("progress:50/1000@main", "finished:/cache/img.png@main"), listener.events);
+    }
+
+    @Test
+    public void teardownBeforeDelivery_dropsProgressAndFinish() {
+        RecordingListener listener = new RecordingListener();
+        ImageGetterAsyncTask task = newStubTask("/cache/img.png");
+        task.setRequestStatusChangedListener(listener);
+
+        task.executeOnExecutor(DIRECT_EXECUTOR);
+        // Modélise ImageDownloader.stopAllCurrentTasks() pendant que les vignettes se chargent.
+        task.setRequestStatusChangedListener(null);
+        task.cancel();
+
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertTrue("Rien ne doit être livré après stopAllCurrentTasks().", listener.events.isEmpty());
+    }
+}


### PR DESCRIPTION
Réimplémentation maison minimale d’AsyncTask, avec ajout de tests unitaires (qui sont limités dans leurs capacités), dans le premier commit.

Le second et troisième commit ajoutent des tests [Robolectric](https://developer.android.com/training/testing/local-tests/robolectric) afin de pouvoir simuler avec un [Looper](https://developer.android.com/reference/android/os/Looper) (synthétique, réimplémenté du côté de Robolectric).

J’ai aussi testé manuellement en faisant une rotation écran (ce qui détruit et recrée activité et fragment) dans le simulateur tandis qu’un topic chargeait. Enfin, je crois que mon timing a fini par être bon.