### PR TITLE
Build : Suppression de la tâche 'clean' inutile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,3 @@ allprojects {
         mavenCentral()
     }
 }
-
-tasks.register('clean', Delete) {
-    delete rootProject.buildDir
-}


### PR DESCRIPTION
Supprimé du template des nouveaux projets par Google fin 2021 : https://android.googlesource.com/platform/tools/adt/idea/+/ee4da7026f9841b9a0d5d6e22e918728bce09dd8
> The "clean" task was used by AGP to put its build cache artifacts, in the project build dir, but this cache is not used anymore.

Les fichiers de l’appli atterrissent dans `app/build`, pas dans `build`.