### PR TITLE
Thème « Système (Clair ou Noir) »

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/MainApplication.java
+++ b/app/src/main/java/com/franckrj/respawnirc/MainApplication.java
@@ -29,7 +29,7 @@ public class MainApplication extends Application {
         super.onCreate();
 
         PrefsManager.initializeSharedPrefs(getApplicationContext());
-        ThemeManager.updateThemeUsed();
+        ThemeManager.updateThemeUsed(getResources());
         ThemeManager.updateToolbarTextColor();
         ThemeManager.updateColorsUsed(getResources());
         AccountManager.loadListOfAccounts();

--- a/app/src/main/java/com/franckrj/respawnirc/SettingsFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/SettingsFragment.java
@@ -115,7 +115,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
                 editTextPref.setText(String.valueOf(prefValue));
             }
         } else if (key.equals(getString(R.string.settingsThemeUsed))) {
-            ThemeManager.updateThemeUsed();
+            ThemeManager.updateThemeUsed(getResources());
 
             if (getActivity() != null) {
                 getActivity().recreate();

--- a/app/src/main/java/com/franckrj/respawnirc/base/AbsThemedActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/base/AbsThemedActivity.java
@@ -23,6 +23,7 @@ public abstract class AbsThemedActivity extends AbsBaseActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        ThemeManager.updateThemeUsed(getResources());
         ThemeManager.changeActivityTheme(this);
         ThemeManager.changeActivityToolbarTextColor(this);
         ThemeManager.changeActivityThemedColorsIfNeeded(this);
@@ -51,6 +52,7 @@ public abstract class AbsThemedActivity extends AbsBaseActivity {
     public void onResume() {
         super.onResume();
 
+        ThemeManager.updateThemeUsed(getResources());
         if ((lastThemeUsed != ThemeManager.getThemeUsed()) || (lastHeaderColorUsed != ThemeManager.getHeaderColorUsedForThemeLight()) ||
                 (lastPrimaryColorUsed != ThemeManager.getPrimaryColorIdUsedForThemeLight()) ||
                 (lastTopicNameAndAccentColorUsed != ThemeManager.getTopicNameAndAccentColorIdUsedForThemeLight()) ||

--- a/app/src/main/java/com/franckrj/respawnirc/utils/ThemeManager.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/ThemeManager.java
@@ -2,6 +2,7 @@ package com.franckrj.respawnirc.utils;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
@@ -69,7 +70,7 @@ public class ThemeManager {
         }
     }
 
-    public static void updateThemeUsed() {
+    public static void updateThemeUsed(Resources res) {
         String themeStringId = PrefsManager.getString(PrefsManager.StringPref.Names.THEME_USED);
 
         switch (themeStringId) {
@@ -85,10 +86,18 @@ public class ThemeManager {
             case "3":
                 themeUsed = ThemeName.BLACK_THEME;
                 break;
+            case "4":
+                themeUsed = systemThemeUsesDarkMode(res) ? ThemeName.BLACK_THEME : ThemeName.LIGHT_THEME;
+                break;
             default:
                 themeUsed = ThemeName.LIGHT_THEME;
                 break;
         }
+    }
+
+    private static boolean systemThemeUsesDarkMode(Resources res) {
+        int nightModeFlags = res.getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        return nightModeFlags == Configuration.UI_MODE_NIGHT_YES;
     }
 
     public static void updateToolbarTextColor() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="dark">Sombre</string>
     <string name="style">Style</string>
     <string name="black">Noir</string>
+    <string name="systemTheme">Système (Clair ou Noir)</string>
     <string name="messages">Messages</string>
     <string name="message">Message</string>
     <string name="settingsModeForumTitle">Mode forum</string>
@@ -371,6 +372,14 @@
         <item>@string/grey</item>
         <item>@string/dark</item>
         <item>@string/black</item>
+        <item>@string/systemTheme</item>
+    </string-array>
+    <string-array name="choicesForThemesValue">
+        <item>"0"</item>
+        <item>"1"</item>
+        <item>"2"</item>
+        <item>"3"</item>
+        <item>"4"</item>
     </string-array>
     <string-array name="choicesForLinkTypeForInternalBrowser">
         <item>@string/allLinks</item>
@@ -392,12 +401,6 @@
         <item>"0"</item>
         <item>"1"</item>
         <item>"2"</item>
-    </string-array>
-    <string-array name="fourChoicesValue">
-        <item>"0"</item>
-        <item>"1"</item>
-        <item>"2"</item>
-        <item>"3"</item>
     </string-array>
     <string-array name="fontSizeChoicesValue">
         <item>"10"</item>

--- a/app/src/main/res/xml/style_settings.xml
+++ b/app/src/main/res/xml/style_settings.xml
@@ -10,7 +10,7 @@
             android:title="@string/theme"
             android:summary="%s"
             android:entries="@array/choicesForThemesReadable"
-            android:entryValues="@array/fourChoicesValue"/>
+            android:entryValues="@array/choicesForThemesValue"/>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
> Nouvelle valeur de préférence « 4 » résolue à la volée vers le thème Clair ou Noir selon le mode nuit de l'OS, avec re-résolution dans onCreate et onResume pour suivre les changements à chaud. Remplace le tableau fourChoicesValue par choicesForThemesValue.