### PR TITLE
Correction du crash en arrière-plan sur grosses pages

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.franckrj.respawnirc.NetworkBroadcastReceiver;
@@ -34,13 +35,13 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
     public static final int MODE_IRC = 0;
     public static final int MODE_FORUM = 1;
 
-    protected static final String SAVE_ALL_MESSAGES_SHOWED = "saveAllCurrentMessagesShowed";
     protected static final String SAVE_GO_TO_BOTTOM_PAGE_LOADING = "saveGoToBottomPageLoading";
     protected static final String SAVE_ANCHOR_FOR_NEXT_LOAD = "saveAnchorForNextLoad";
     protected static final String SAVE_SETTINGS_PSEUDO_OF_AUTHOR = "saveSettingsPseudoOfAuthor";
     protected static final String SAVE_MESSAGES_ARE_FROM_IGNORED_PSEUDOS = "saveMessagesAreFromIgnoredPseudos";
 
     protected AbsJVCTopicGetter absGetterForTopic = null;
+    protected ShowTopicViewModel topicViewModel = null;
     protected TextView errorBackgroundMessage = null;
     protected ListView jvcMsgList = null;
     protected JVCTopicAdapter adapterForTopic = null;
@@ -339,6 +340,7 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
+        topicViewModel = new ViewModelProvider(this).get(ShowTopicViewModel.class);
         adapterForTopic = new JVCTopicAdapter(requireActivity(), currentSettings);
         initializeGetterForMessages();
         initializeAdapter();
@@ -379,7 +381,7 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
         jvcMsgList.setAdapter(adapterForTopic);
 
         if (savedInstanceState != null) {
-            ArrayList<JVCParser.MessageInfos> allCurrentMessagesShowed = savedInstanceState.getParcelableArrayList(SAVE_ALL_MESSAGES_SHOWED);
+            ArrayList<JVCParser.MessageInfos> allCurrentMessagesShowed = topicViewModel.listOfMessagesShowed;
             goToBottomAtPageLoading = savedInstanceState.getBoolean(SAVE_GO_TO_BOTTOM_PAGE_LOADING, false);
             anchorForNextLoad = savedInstanceState.getString(SAVE_ANCHOR_FOR_NEXT_LOAD, null);
             currentSettings.pseudoOfAuthor = savedInstanceState.getString(SAVE_SETTINGS_PSEUDO_OF_AUTHOR, "");
@@ -446,16 +448,7 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-        long totalLengthOfMessages = 0;
-
-        for (JVCParser.MessageInfos currentMessage : adapterForTopic.getAllItems()) {
-            totalLengthOfMessages += currentMessage.messageRaw.length();
-        }
-
-        //todo fix temporaire
-        if (totalLengthOfMessages < 150_000) {
-            outState.putParcelableArrayList(SAVE_ALL_MESSAGES_SHOWED, adapterForTopic.getAllItems());
-        }
+        topicViewModel.listOfMessagesShowed = adapterForTopic.getAllItems();
         outState.putBoolean(SAVE_GO_TO_BOTTOM_PAGE_LOADING, goToBottomAtPageLoading);
         outState.putString(SAVE_ANCHOR_FOR_NEXT_LOAD, anchorForNextLoad);
         outState.putString(SAVE_SETTINGS_PSEUDO_OF_AUTHOR, currentSettings.pseudoOfAuthor);

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicViewModel.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicViewModel.java
@@ -1,0 +1,11 @@
+package com.franckrj.respawnirc.jvctopic.jvctopicviewers;
+
+import androidx.lifecycle.ViewModel;
+
+import com.franckrj.respawnirc.utils.JVCParser;
+
+import java.util.ArrayList;
+
+public class ShowTopicViewModel extends ViewModel {
+    public ArrayList<JVCParser.MessageInfos> listOfMessagesShowed = null;
+}


### PR DESCRIPTION
On est pas censé sauvegarder de grosses données dans le saved instance state, 50 Ko maximum sont préconisées ; on est censé utiliser un ViewModel pour les données à garder dans les changements de configuration (rotation d’écran etc.). Claude Fable m’a donc créé un ViewModel minimal et a testé que ça corrige bien le problème sur cette page lourde https://www.jeuxvideo.com/forums/42-4443-77150658-1-0-1-0-grosse-page-lourde.htm.

> Topics : Sauvegarde des messages affichés dans un ViewModel plutôt que dans le bundle d'état.
> 
> Sur les grosses pages, la liste des MessageInfos mise dans le bundle par onSaveInstanceState dépassait le tampon binder, ce qui tuait l'appli avec un TransactionTooLargeException au passage en arrière-plan (crashs silencieux à répétition signalés sur la 2.1.19). Le garde-fou existant (150 000 caractères de messageRaw au maximum) sous-comptait le poids réel en ignorant messageNotParsed et signatureNotParsed ainsi que l'encodage UTF-16 du Parcel : sur une page de test réelle, construite exprès pour être très lourde, un seul fragment sous la limite produisait un parcel de 2 092 900 octets (dont 2 078 648 pour saveAllCurrentMessagesShowed).
> 
> Les messages sont maintenant conservés dans un ViewModel porté par le fragment : ils survivent aux rotations sans re-téléchargement, et après une mort du processus la page est simplement re-téléchargée grâce aux métadonnées légères restées dans le bundle (URL, dernier id), comme le faisait déjà le chemin dégradé du garde-fou. Le « fix temporaire » de 2019 disparaît.
> 
> C'est le découpage que préconise la documentation Android. « Save UI states » (https://developer.android.com/topic/libraries/architecture/saving-states) : « ViewModel is ideal for storing and managing UI-related data while the user is actively using the application » ; et pour le bundle : « Don't use saved state to store large amounts of data, such as bitmaps, nor complex data structures that require lengthy serialization or deserialization. Instead, store only primitive types and simple, small objects such as String. » « Parcelables and bundles » (https://developer.android.com/guide/components/activities/parcelables-and-bundles) chiffre les limites : « We recommend that you keep saved state to less than 50KB of data » et « The Binder transaction buffer has a limited fixed size, currently 1MB, which is shared by all transactions in progress for the process. [...] When the size limit is exceeded, a TransactionTooLargeException is thrown. »
> 
> Testé sur émulateur API 34 avec un vrai topic très lourd : avant, un appui sur Home tuait le processus immédiatement ; après, le processus survit au passage en arrière-plan et au retour, la rotation restaure la liste instantanément depuis le ViewModel, et une mort du processus en arrière-plan aboutit à un rechargement propre de la page au retour.