### PR TITLE
Chemin du login 2026

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/ConnectActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/ConnectActivity.java
@@ -129,7 +129,7 @@ public class ConnectActivity extends AbsHomeIsBackActivity {
         // Disables dark mode as a side effect, however.
         WebStorage.getInstance().deleteAllData();
 
-        jvcWebView.loadUrl("https://www.jeuxvideo.com/login");
+        jvcWebView.loadUrl("https://www.jeuxvideo.com/sso/login");
 
         PrefsManager.putInt(PrefsManager.IntPref.Names.NUMBER_OF_WEBVIEW_OPEN_SINCE_CACHE_CLEARED,
                 PrefsManager.getInt(PrefsManager.IntPref.Names.NUMBER_OF_WEBVIEW_OPEN_SINCE_CACHE_CLEARED) + 1);


### PR DESCRIPTION
Alors rien de très fou je me demande même si c'est la peine de merger

Depuis qu'ils ont mis en place le nouveau formulaire d'inscription

Tous les endpoints de connexion convergent en redirection 301 

de
`https://www.jeuxvideo.com/login*`
vers
`https://www.jeuxvideo.com/sso/login `

Alors pour l'instant la redirection est toujours là et à mon avis elle va le rester mais dans le doute comme le site est souvant refactor Et surtout comme **cette redirection fait perdre les paramètres après l'uRL**  

Je me permets de le mettre là j'ai cherché avec un fichier python Car je connais peu le projet j'ai trouvé aucun autre endroit où auth existe . 

**Note pour plus tard :** La connexion modérateur accès étendu est toujours au même endroit 