### PR TITLE
Citation : Suppression citations imbriquées >5

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/JVCParser.java
@@ -908,7 +908,9 @@ public final class JVCParser {
 
     public static String buildMessageQuoted(MessageInfos thisMessageInfo) {
         return "> Le " + thisMessageInfo.wholeDate + " " + thisMessageInfo.pseudo + " a écrit :\n>"
-                + thisMessageInfo.messageRaw.replaceAll("\n", "\n>");
+                + thisMessageInfo.messageRaw.replaceAll("(?m)^> *> *> *>.*\n", "")
+                .replaceAll("\n", "\n>")
+                ;
     }
 
     public static String parsingAjaxMessages(String ajaxMessage) {


### PR DESCRIPTION
Les citations telles que :

```
>> >> >Citation du passé
```

sont désormais supprimées pour alléger les messages.

C'est extrêmement trivial.