### PR TITLE
Fix crash R8 d’AGP 9.3.0 + config optimisation moderne

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,9 +21,9 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled true
-            shrinkResources = true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            optimization {
+                enable = true
+            }
         }
         debug {
             applicationIdSuffix ".dev"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -4,3 +4,18 @@
 # méthodes et lignes d'origine.
 -renamesourcefileattribute SourceFile
 -keepattributes SourceFile,LineNumberTable
+
+# La lib preferencex remplace par réflexion (Field.set) le mPreferenceManager de
+# PreferenceFragmentCompat par son PreferenceManagerFix, qui ajoute notamment
+# "com.takisoft.preferencex" aux packages par défaut du PreferenceInflater. R8 ne voit
+# pas cette écriture : il suppose que le champ contient toujours un PreferenceManager
+# de base, inline inflateFromResource() et le Fix ne s'exécute jamais, d'où un
+# ClassNotFoundException sur ColorPickerPreference en release. Épingler les champs
+# accédés par réflexion (recherchés par type par la lib, d'où le joker sur le nom)
+# désactive cette optimisation.
+-keepclassmembers class androidx.preference.PreferenceFragmentCompat {
+    androidx.preference.PreferenceManager *;
+}
+-keepclassmembers class androidx.preference.PreferenceManager {
+    android.content.SharedPreferences$Editor *;
+}

--- a/app/src/release/keepRules/preferencex.keep
+++ b/app/src/release/keepRules/preferencex.keep
@@ -1,10 +1,3 @@
-# Conserver les numéros de ligne pour pouvoir désobfusquer les stack traces des rapports
-# de crash en release (en masquant le nom de fichier source d'origine). À recroiser avec
-# le mapping.txt du build correspondant (build/outputs/mapping/) pour retrouver classes,
-# méthodes et lignes d'origine.
--renamesourcefileattribute SourceFile
--keepattributes SourceFile,LineNumberTable
-
 # La lib preferencex remplace par réflexion (Field.set) le mPreferenceManager de
 # PreferenceFragmentCompat par son PreferenceManagerFix, qui ajoute notamment
 # "com.takisoft.preferencex" aux packages par défaut du PreferenceInflater. R8 ne voit

--- a/app/src/release/keepRules/stacktraces.keep
+++ b/app/src/release/keepRules/stacktraces.keep
@@ -1,0 +1,6 @@
+# Conserver les numéros de ligne pour pouvoir désobfusquer les stack traces des rapports
+# de crash en release (en masquant le nom de fichier source d'origine). À recroiser avec
+# le mapping.txt du build correspondant (build/outputs/mapping/) pour retrouver classes,
+# méthodes et lignes d'origine.
+-renamesourcefileattribute SourceFile
+-keepattributes SourceFile,LineNumberTable


### PR DESCRIPTION
Le crash de preferencex en build release est causé par le R8 d’AGP 9.3.0 qui « fait de la propagation de type sur les champs ». On ajoute donc des règles proguard (commentées) dans le premier commit.

Dans le second commit je passe à la nouvelle config d’optimisation d’AGP 9.3.0. Ça ne change rien au résultat, c’est juste plus propre et moderne.