### PR TITLE
Legacy : onActivityCreated -> onViewCreated dans les fragments

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/jvcforum/jvcforumtools/ShowForumFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvcforum/jvcforumtools/ShowForumFragment.java
@@ -275,8 +275,8 @@ public class ShowForumFragment extends AbsShowSomethingFragment {
     }
 
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
         getterForForum = new JVCForumGetter();
         adapterForForum = new JVCForumAdapter(requireActivity());

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
@@ -337,8 +337,8 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
     }
 
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
         topicViewModel = new ViewModelProvider(this).get(ShowTopicViewModel.class);
         adapterForTopic = new JVCTopicAdapter(requireActivity(), currentSettings);

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicModeForumFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicModeForumFragment.java
@@ -9,6 +9,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
 
 import com.franckrj.respawnirc.utils.IgnoreListManager;
 import com.franckrj.respawnirc.NetworkBroadcastReceiver;
@@ -193,8 +194,8 @@ public class ShowTopicModeForumFragment extends AbsShowTopicFragment {
     }
 
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
         swipeRefresh.setOnRefreshListener(listenerForRefresh);
 

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicModeIRCFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicModeIRCFragment.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
 
 import com.franckrj.respawnirc.utils.IgnoreListManager;
 import com.franckrj.respawnirc.R;
@@ -178,8 +179,8 @@ public class ShowTopicModeIRCFragment extends AbsShowTopicFragment {
     }
 
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
         swipeRefresh.setEnabled(false);
 


### PR DESCRIPTION
> onActivityCreated est déprécié dans AndroidX Fragment. Le code d'initialisation des quatre fragments concernés est déplacé dans onViewCreated, qui s'exécute juste après onCreateView : il ne manipule que des vues créées dans onCreateView et l'activité déjà attachée, le comportement reste donc inchangé.