### PR TITLE
Build : Suppression de la dépendance aux .jar locaux du dossier libs.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.7.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'


### PR DESCRIPTION
Une ligne du template Android Studio qui déclarait comme dépendances tous les .jar présents dans app/libs/, ce qu’on n’a pas et n’aura vraisemblablement jamais.