### PR TITLE
Edge-to-edge : gestion des marges en orientation paysage

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/base/AbsToolbarActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/base/AbsToolbarActivity.java
@@ -20,10 +20,13 @@ public abstract class AbsToolbarActivity extends AbsThemedActivity {
 
         /* Edge-to-edge : la barre d'état devient transparente, on ajoute donc l'inset du haut en
            padding sur la toolbar pour que son fond (colorPrimary) colore la bande de status bar et
-           que son contenu reste dessous. Sans effet tant que l'edge-to-edge n'est pas actif (inset à 0). */
+           que son contenu reste dessous. Sans effet tant que l'edge-to-edge n'est pas actif (inset à 0).
+           Le latéral est symétrique (max des insets gauche/droite de barre de navigation et découpe du
+           capteur) pour que le contenu reste centré quel que soit le côté du capteur en paysage. */
         ViewCompat.setOnApplyWindowInsetsListener(myToolbar, (view, windowInsets) -> {
             Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-            view.setPadding(bars.left, bars.top, bars.right, 0);
+            int side = Math.max(bars.left, bars.right);
+            view.setPadding(side, bars.top, side, 0);
             return windowInsets;
         });
 

--- a/app/src/main/java/com/franckrj/respawnirc/base/AbsToolbarActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/base/AbsToolbarActivity.java
@@ -3,9 +3,10 @@ package com.franckrj.respawnirc.base;
 import androidx.annotation.IdRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
-import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
+
+import com.franckrj.respawnirc.utils.Utils;
 
 public abstract class AbsToolbarActivity extends AbsThemedActivity {
     protected Toolbar initToolbar(@IdRes int idOfToolbar) {
@@ -24,9 +25,9 @@ public abstract class AbsToolbarActivity extends AbsThemedActivity {
            Le latéral est symétrique (max des insets gauche/droite de barre de navigation et découpe du
            capteur) pour que le contenu reste centré quel que soit le côté du capteur en paysage. */
         ViewCompat.setOnApplyWindowInsetsListener(myToolbar, (view, windowInsets) -> {
-            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-            int side = Math.max(bars.left, bars.right);
-            view.setPadding(side, bars.top, side, 0);
+            int topInset = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()).top;
+            int side = Utils.getSymmetricSideInset(windowInsets);
+            view.setPadding(side, topInset, side, 0);
             return windowInsets;
         });
 

--- a/app/src/main/java/com/franckrj/respawnirc/jvcforum/SearchTopicInForumActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvcforum/SearchTopicInForumActivity.java
@@ -127,6 +127,7 @@ public class SearchTopicInForumActivity extends AbsHomeIsBackActivity implements
         pageNavigation.initializePagerView(findViewById(R.id.pager_searchtopic));
         pageNavigation.initializeNavigationButtons(findViewById(R.id.firstpage_button_searchtopic), findViewById(R.id.previouspage_button_searchtopic),
                 findViewById(R.id.currentpage_button_searchtopic), findViewById(R.id.nextpage_button_searchtopic), null);
+        Utils.addSymmetricSideInsetPadding(findViewById(R.id.navigation_layout_searchtopic));
         pageNavigation.updateAdapterForPagerView();
 
         searchModeRadioGroup = findViewById(R.id.radiogroup_layout_searchtopic);

--- a/app/src/main/java/com/franckrj/respawnirc/jvcforum/SearchTopicInForumActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvcforum/SearchTopicInForumActivity.java
@@ -131,6 +131,7 @@ public class SearchTopicInForumActivity extends AbsHomeIsBackActivity implements
         pageNavigation.updateAdapterForPagerView();
 
         searchModeRadioGroup = findViewById(R.id.radiogroup_layout_searchtopic);
+        Utils.addSymmetricSideInsetPadding(searchModeRadioGroup);
         searchModeRadioGroup.setOnCheckedChangeListener(searchTypeChangedListener);
 
         if (getIntent() != null && savedInstanceState == null) {

--- a/app/src/main/java/com/franckrj/respawnirc/jvcforum/ShowForumActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvcforum/ShowForumActivity.java
@@ -183,6 +183,7 @@ public class ShowForumActivity extends AbsNavigationViewActivity implements Show
         pageNavigation.initializePagerView(findViewById(R.id.pager_showforum));
         pageNavigation.initializeNavigationButtons(findViewById(R.id.firstpage_button_showforum), findViewById(R.id.previouspage_button_showforum),
                 findViewById(R.id.currentpage_button_showforum), findViewById(R.id.nextpage_button_showforum), null);
+        Utils.addSymmetricSideInsetPadding(findViewById(R.id.header_layout_showforum));
         pageNavigation.updateAdapterForPagerView();
 
         if (savedInstanceState == null) {

--- a/app/src/main/java/com/franckrj/respawnirc/jvcforum/jvcforumtools/JVCForumAdapter.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvcforum/jvcforumtools/JVCForumAdapter.java
@@ -36,6 +36,7 @@ public class JVCForumAdapter extends BaseAdapter {
     private @ColorInt int defaultBackgroundColor = 0;
     private int topicTitleSizeInSp = 14;
     private int topicInfosSizeInSp = 14;
+    private int sideInset = 0;
     private Drawable iconMarqueOn;
     private Drawable iconMarqueOff;
     private Drawable iconDossier2;
@@ -111,6 +112,17 @@ public class JVCForumAdapter extends BaseAdapter {
 
     public void setDefaultBackgroundColor(@ColorInt int newColor) {
         defaultBackgroundColor = newColor;
+    }
+
+    /* Edge-to-edge : inset latéral (barre de navigation et découpe du capteur) appliqué en padding sur
+       chaque ligne. Le fond de la ligne reste pleine largeur (passe sous le capteur en paysage) mais
+       son contenu est décalé pour ne pas passer dessous. On applique la même valeur des deux côtés
+       pour garder un décalage symétrique quel que soit le côté du capteur. */
+    public void setSideInset(int newInset) {
+        if (sideInset != newInset) {
+            sideInset = newInset;
+            notifyDataSetChanged();
+        }
     }
 
     public void removeAllItems() {
@@ -197,6 +209,8 @@ public class JVCForumAdapter extends BaseAdapter {
             holder.titleLine.setTextSize(TypedValue.COMPLEX_UNIT_SP, topicTitleSizeInSp);
             holder.authorLine.setTextSize(TypedValue.COMPLEX_UNIT_SP, topicInfosSizeInSp);
             holder.dateLine.setTextSize(TypedValue.COMPLEX_UNIT_SP, topicInfosSizeInSp);
+            holder.basePaddingLeft = convertView.getPaddingLeft();
+            holder.basePaddingRight = convertView.getPaddingRight();
             convertView.setTag(holder);
         } else {
             holder = (ViewHolder) convertView.getTag();
@@ -241,6 +255,9 @@ public class JVCForumAdapter extends BaseAdapter {
             convertView.setBackgroundColor(defaultBackgroundColor);
         }
 
+        convertView.setPadding(holder.basePaddingLeft + sideInset, convertView.getPaddingTop(),
+                holder.basePaddingRight + sideInset, convertView.getPaddingBottom());
+
         holder.titleLine.invalidate();
         holder.titleLine.requestLayout();
         convertView.invalidate();
@@ -253,6 +270,8 @@ public class JVCForumAdapter extends BaseAdapter {
         public TextView authorLine;
         public TextView dateLine;
         public ImageView topicIcon;
+        public int basePaddingLeft;
+        public int basePaddingRight;
     }
 
     private class ContentHolder {

--- a/app/src/main/java/com/franckrj/respawnirc/jvcforum/jvcforumtools/ShowForumFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvcforum/jvcforumtools/ShowForumFragment.java
@@ -3,6 +3,9 @@ package com.franckrj.respawnirc.jvcforum.jvcforumtools;
 import android.os.Bundle;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -271,6 +274,19 @@ public class ShowForumFragment extends AbsShowSomethingFragment {
 
         swipeRefresh.setOnRefreshListener(listenerForRefresh);
 
+        /* Edge-to-edge : on capture les insets latéraux (barre de navigation et découpe du capteur)
+           sur le parent de la liste, car le listener du bas est déjà posé sur la ListView. On prend le
+           max des deux côtés pour un décalage symétrique, et on le transmet à l'adapter qui l'applique
+           en padding sur chaque ligne (le fond reste pleine largeur, seul le contenu est décalé). Les
+           insets sont renvoyés non consommés pour que la ListView reçoive quand même les siens. */
+        ViewCompat.setOnApplyWindowInsetsListener(swipeRefresh, (v, windowInsets) -> {
+            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            if (adapterForForum != null) {
+                adapterForForum.setSideInset(Math.max(bars.left, bars.right));
+            }
+            return windowInsets;
+        });
+
         return mainView;
     }
 
@@ -299,6 +315,7 @@ public class ShowForumFragment extends AbsShowSomethingFragment {
         errorBackgroundMessage.setVisibility(View.GONE);
         swipeRefresh.setColorSchemeResources(R.color.colorControlHighlightThemeLight);
         jvcTopicList.setAdapter(adapterForForum);
+        ViewCompat.requestApplyInsets(swipeRefresh);
 
         if (savedInstanceState != null) {
             ArrayList<JVCParser.TopicInfos> allCurrentTopicsShowed = savedInstanceState.getParcelableArrayList(SAVE_ALL_TOPICS_SHOWED);

--- a/app/src/main/java/com/franckrj/respawnirc/jvcforum/jvcforumtools/ShowForumFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvcforum/jvcforumtools/ShowForumFragment.java
@@ -3,9 +3,6 @@ package com.franckrj.respawnirc.jvcforum.jvcforumtools;
 import android.os.Bundle;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
-import androidx.core.graphics.Insets;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -274,19 +271,6 @@ public class ShowForumFragment extends AbsShowSomethingFragment {
 
         swipeRefresh.setOnRefreshListener(listenerForRefresh);
 
-        /* Edge-to-edge : on capture les insets latéraux (barre de navigation et découpe du capteur)
-           sur le parent de la liste, car le listener du bas est déjà posé sur la ListView. On prend le
-           max des deux côtés pour un décalage symétrique, et on le transmet à l'adapter qui l'applique
-           en padding sur chaque ligne (le fond reste pleine largeur, seul le contenu est décalé). Les
-           insets sont renvoyés non consommés pour que la ListView reçoive quand même les siens. */
-        ViewCompat.setOnApplyWindowInsetsListener(swipeRefresh, (v, windowInsets) -> {
-            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-            if (adapterForForum != null) {
-                adapterForForum.setSideInset(Math.max(bars.left, bars.right));
-            }
-            return windowInsets;
-        });
-
         return mainView;
     }
 
@@ -315,7 +299,9 @@ public class ShowForumFragment extends AbsShowSomethingFragment {
         errorBackgroundMessage.setVisibility(View.GONE);
         swipeRefresh.setColorSchemeResources(R.color.colorControlHighlightThemeLight);
         jvcTopicList.setAdapter(adapterForForum);
-        ViewCompat.requestApplyInsets(swipeRefresh);
+        /* Edge-to-edge : on capture l'inset latéral sur le parent de la liste (le listener du bas est déjà
+           posé sur la ListView) et on le transmet à l'adapter qui décale le contenu de chaque ligne. */
+        Utils.forwardSymmetricSideInset(swipeRefresh, adapterForForum::setSideInset);
 
         if (savedInstanceState != null) {
             ArrayList<JVCParser.TopicInfos> allCurrentTopicsShowed = savedInstanceState.getParcelableArrayList(SAVE_ALL_TOPICS_SHOWED);

--- a/app/src/main/java/com/franckrj/respawnirc/jvcforumlist/JVCForumListAdapter.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvcforumlist/JVCForumListAdapter.java
@@ -21,6 +21,7 @@ public class JVCForumListAdapter extends BaseAdapter {
     private ArrayList<JVCParser.NameAndLink> currentListOfForums = new ArrayList<>();
     private LayoutInflater serviceInflater;
     private Activity parentActivity;
+    private int sideInset = 0;
 
     public JVCForumListAdapter(Activity newParentActivity) {
         parentActivity = newParentActivity;
@@ -35,6 +36,17 @@ public class JVCForumListAdapter extends BaseAdapter {
         }
 
         notifyDataSetChanged();
+    }
+
+    /* Edge-to-edge : inset latéral (barre de navigation et découpe du capteur) appliqué en padding sur
+       chaque ligne. Le fond de la ligne reste pleine largeur (passe sous le capteur en paysage) mais son
+       contenu est décalé pour ne pas passer dessous. On applique la même valeur des deux côtés pour garder
+       un décalage symétrique quel que soit le côté du capteur. */
+    public void setSideInset(int newInset) {
+        if (sideInset != newInset) {
+            sideInset = newInset;
+            notifyDataSetChanged();
+        }
     }
 
     public String getForumLinkAtThisPos(int position) {
@@ -77,6 +89,8 @@ public class JVCForumListAdapter extends BaseAdapter {
             holder = new ViewHolder();
             convertView = serviceInflater.inflate(R.layout.jvcforums_row, parent, false);
             holder.forumTitle = convertView.findViewById(R.id.title_forum_jvcforums_text_row);
+            holder.basePaddingLeft = convertView.getPaddingLeft();
+            holder.basePaddingRight = convertView.getPaddingRight();
             convertView.setTag(holder);
         } else {
             holder = (ViewHolder) convertView.getTag();
@@ -85,10 +99,15 @@ public class JVCForumListAdapter extends BaseAdapter {
         convertView.setBackgroundColor(ThemeManager.getColorInt(R.attr.themedDefaultBackgroundColor, parentActivity));
         holder.forumTitle.setText(currentListOfForums.get(position).name);
 
+        convertView.setPadding(holder.basePaddingLeft + sideInset, convertView.getPaddingTop(),
+                holder.basePaddingRight + sideInset, convertView.getPaddingBottom());
+
         return convertView;
     }
 
     private class ViewHolder {
         public TextView forumTitle;
+        public int basePaddingLeft;
+        public int basePaddingRight;
     }
 }

--- a/app/src/main/java/com/franckrj/respawnirc/jvcforumlist/SelectForumInListActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvcforumlist/SelectForumInListActivity.java
@@ -18,6 +18,9 @@ import android.widget.TextView;
 
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.transition.TransitionManager;
 
@@ -216,6 +219,20 @@ public class SelectForumInListActivity extends AbsNavigationViewActivity impleme
         adapterForForumList = new JVCForumListAdapter(this);
         forumListView.setAdapter(adapterForForumList);
         forumListView.setOnItemClickListener(forumClickedInListView);
+
+        /* Edge-to-edge : les lignes de résultats de recherche occupent toute la largeur, on décale donc
+           seulement leur contenu en gardant leur fond pleine largeur. On capture les insets latéraux sur le
+           parent de la liste (le SwipeRefreshLayout) pour ne pas monopoliser le listener de la ListView (qui
+           gère déjà son inset du bas) et on les renvoie non consommés. On prend le max des deux côtés pour un
+           décalage symétrique, transmis à l'adapter qui l'applique en padding sur chaque ligne. */
+        ViewCompat.setOnApplyWindowInsetsListener(swipeRefresh, (v, windowInsets) -> {
+            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            if (adapterForForumList != null) {
+                adapterForForumList.setSideInset(Math.max(bars.left, bars.right));
+            }
+            return windowInsets;
+        });
+        ViewCompat.requestApplyInsets(swipeRefresh);
 
         if (savedInstanceState != null) {
             lastSearchedText = savedInstanceState.getString(SAVE_SEARCH_FORUM_CONTENT, null);

--- a/app/src/main/java/com/franckrj/respawnirc/jvcforumlist/SelectForumInListActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvcforumlist/SelectForumInListActivity.java
@@ -192,6 +192,9 @@ public class SelectForumInListActivity extends AbsNavigationViewActivity impleme
         noResultFoundTextView = findViewById(R.id.text_noresultfound_selectforum);
         baseForumListLayout = findViewById(R.id.base_forumlist_layout_selectforum);
         Utils.addBottomNavInsetPadding(baseForumListLayout);
+        /* Edge-to-edge : les cartes de catégories flottent, on les décale donc via une marge (padding
+           latéral symétrique sur leur conteneur) pour qu'elles ne passent pas sous le capteur en paysage. */
+        Utils.addSymmetricSideInsetPadding(findViewById(R.id.forumlist_cards_layout_selectforum));
         swipeRefresh.setEnabled(false);
         swipeRefresh.setColorSchemeResources(R.color.colorControlHighlightThemeLight);
         noResultFoundTextView.setVisibility(View.GONE);

--- a/app/src/main/java/com/franckrj/respawnirc/jvcforumlist/SelectForumInListActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvcforumlist/SelectForumInListActivity.java
@@ -18,9 +18,6 @@ import android.widget.TextView;
 
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
-import androidx.core.graphics.Insets;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.transition.TransitionManager;
 
@@ -220,19 +217,10 @@ public class SelectForumInListActivity extends AbsNavigationViewActivity impleme
         forumListView.setAdapter(adapterForForumList);
         forumListView.setOnItemClickListener(forumClickedInListView);
 
-        /* Edge-to-edge : les lignes de résultats de recherche occupent toute la largeur, on décale donc
-           seulement leur contenu en gardant leur fond pleine largeur. On capture les insets latéraux sur le
-           parent de la liste (le SwipeRefreshLayout) pour ne pas monopoliser le listener de la ListView (qui
-           gère déjà son inset du bas) et on les renvoie non consommés. On prend le max des deux côtés pour un
-           décalage symétrique, transmis à l'adapter qui l'applique en padding sur chaque ligne. */
-        ViewCompat.setOnApplyWindowInsetsListener(swipeRefresh, (v, windowInsets) -> {
-            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-            if (adapterForForumList != null) {
-                adapterForForumList.setSideInset(Math.max(bars.left, bars.right));
-            }
-            return windowInsets;
-        });
-        ViewCompat.requestApplyInsets(swipeRefresh);
+        /* Edge-to-edge : les lignes de résultats de recherche occupent toute la largeur, on capture donc
+           l'inset latéral sur le parent de la liste (le listener du bas est déjà posé sur la ListView) et on
+           le transmet à l'adapter qui décale le contenu de chaque ligne, fond gardé pleine largeur. */
+        Utils.forwardSymmetricSideInset(swipeRefresh, adapterForForumList::setSideInset);
 
         if (savedInstanceState != null) {
             lastSearchedText = savedInstanceState.getString(SAVE_SEARCH_FORUM_CONTENT, null);

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowTopicActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowTopicActivity.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
@@ -485,11 +486,15 @@ public class ShowTopicActivity extends AbsHomeIsBackActivity implements AbsShowT
         });
 
         /* Edge-to-edge : la barre d'envoi reste au-dessus de la barre de navigation et du clavier
-           (son fond déborde sous la barre de navigation transparente). */
+           (son fond déborde sous la barre de navigation transparente). Son fond garde donc l'apparence
+           de la pleine largeur, mais on décale son contenu (bouton +, zone de texte, bouton d'envoi) en
+           padding latéral symétrique pour qu'il ne passe pas sous le capteur en paysage. */
         ViewCompat.setOnApplyWindowInsetsListener(messageSendLayout, (view, windowInsets) -> {
+            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
             int navBottom = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
             int imeBottom = windowInsets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
-            view.setPadding(view.getPaddingLeft(), view.getPaddingTop(), view.getPaddingRight(), Math.max(navBottom, imeBottom));
+            int side = Math.max(bars.left, bars.right);
+            view.setPadding(side, view.getPaddingTop(), side, Math.max(navBottom, imeBottom));
             return windowInsets;
         });
 

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowTopicActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowTopicActivity.java
@@ -21,7 +21,6 @@ import androidx.annotation.NonNull;
 import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
-import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
@@ -490,10 +489,9 @@ public class ShowTopicActivity extends AbsHomeIsBackActivity implements AbsShowT
            de la pleine largeur, mais on décale son contenu (bouton +, zone de texte, bouton d'envoi) en
            padding latéral symétrique pour qu'il ne passe pas sous le capteur en paysage. */
         ViewCompat.setOnApplyWindowInsetsListener(messageSendLayout, (view, windowInsets) -> {
-            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
             int navBottom = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
             int imeBottom = windowInsets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
-            int side = Math.max(bars.left, bars.right);
+            int side = Utils.getSymmetricSideInset(windowInsets);
             view.setPadding(side, view.getPaddingTop(), side, Math.max(navBottom, imeBottom));
             return windowInsets;
         });

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowTopicActivity.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/ShowTopicActivity.java
@@ -494,6 +494,7 @@ public class ShowTopicActivity extends AbsHomeIsBackActivity implements AbsShowT
         });
 
         pageNavigation.initializeLayoutForAllNavigationButtons(findViewById(R.id.header_layout_showtopic), findViewById(R.id.shadow_header_showtopic));
+        Utils.addSymmetricSideInsetPadding(findViewById(R.id.header_layout_showtopic));
         pageNavigation.initializePagerView(findViewById(R.id.pager_showtopic));
         pageNavigation.initializeNavigationButtons(findViewById(R.id.firstpage_button_showtopic), findViewById(R.id.previouspage_button_showtopic),
                 findViewById(R.id.currentpage_button_showtopic), findViewById(R.id.nextpage_button_showtopic), findViewById(R.id.lastpage_button_showtopic));

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
@@ -14,6 +14,9 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
@@ -56,6 +59,8 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
     protected boolean smoothScrollIsEnabled = true;
     protected boolean hideTotallyMessagesOfIgnoredPseudos = true;
     protected boolean fastRefreshOfImages = false;
+    private int baseMsgListPaddingLeft = 0;
+    private int baseMsgListPaddingRight = 0;
 
     protected final AbsJVCTopicGetter.NewGetterStateListener listenerForNewGetterState = newState -> {
         if (showNoelshackImageType.type == PrefsManager.ShowImageType.WIFI_ONLY && newState == AbsJVCTopicGetter.STATE_LOADING) {
@@ -333,6 +338,16 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
         jvcMsgList = mainView.findViewById(R.id.jvcmessage_view_showtopicfrag);
         swipeRefresh = mainView.findViewById(R.id.swiperefresh_showtopicfrag);
 
+        /* Edge-to-edge : on capture les insets latéraux (barre de navigation et découpe du capteur) sur
+           le parent de la liste (le SwipeRefreshLayout) plutôt que sur la ListView, pour laisser à cette
+           dernière la liberté de son propre listener, et on les renvoie non consommés pour qu'elle reçoive
+           quand même les siens. On prend le max des deux côtés pour un décalage symétrique. */
+        ViewCompat.setOnApplyWindowInsetsListener(swipeRefresh, (v, windowInsets) -> {
+            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            applySideInsetToMessagesList(Math.max(bars.left, bars.right));
+            return windowInsets;
+        });
+
         return mainView;
     }
 
@@ -378,7 +393,11 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
             jvcMsgList.setPadding(0, 0, 0, 3); //pour corriger un bug de smoothscroll
         }
         jvcMsgList.setClipToPadding(false);
+        /* Edge-to-edge : padding latéral de base de la liste, sur lequel on ajoutera l'inset du capteur. */
+        baseMsgListPaddingLeft = jvcMsgList.getPaddingLeft();
+        baseMsgListPaddingRight = jvcMsgList.getPaddingRight();
         jvcMsgList.setAdapter(adapterForTopic);
+        ViewCompat.requestApplyInsets(swipeRefresh);
 
         if (savedInstanceState != null) {
             ArrayList<JVCParser.MessageInfos> allCurrentMessagesShowed = topicViewModel.listOfMessagesShowed;
@@ -418,6 +437,20 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
         if (dontLoadOnFirstTime) {
             absGetterForTopic.stopAllCurrentTask();
             dontLoadOnFirstTime = false;
+        }
+    }
+
+    /* Edge-to-edge : décale le contenu de la liste des messages pour éviter la découpe du capteur en
+       paysage, la même valeur des deux côtés pour rester symétrique. En mode carte, les cartes flottent :
+       on ajoute l'inset en marge autour d'elles (padding latéral de la liste) pour décaler la carte
+       entière. Sinon les lignes occupent toute la largeur : leur fond reste pleine largeur et seul leur
+       contenu est décalé, via un padding posé sur chaque ligne par l'adapter. */
+    private void applySideInsetToMessagesList(int sideInset) {
+        if (cardDesignIsEnabled) {
+            jvcMsgList.setPadding(baseMsgListPaddingLeft + sideInset, jvcMsgList.getPaddingTop(),
+                    baseMsgListPaddingRight + sideInset, jvcMsgList.getPaddingBottom());
+        } else if (adapterForTopic != null) {
+            adapterForTopic.setSideInset(sideInset);
         }
     }
 

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
@@ -14,9 +14,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.core.graphics.Insets;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
@@ -338,16 +335,6 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
         jvcMsgList = mainView.findViewById(R.id.jvcmessage_view_showtopicfrag);
         swipeRefresh = mainView.findViewById(R.id.swiperefresh_showtopicfrag);
 
-        /* Edge-to-edge : on capture les insets latéraux (barre de navigation et découpe du capteur) sur
-           le parent de la liste (le SwipeRefreshLayout) plutôt que sur la ListView, pour laisser à cette
-           dernière la liberté de son propre listener, et on les renvoie non consommés pour qu'elle reçoive
-           quand même les siens. On prend le max des deux côtés pour un décalage symétrique. */
-        ViewCompat.setOnApplyWindowInsetsListener(swipeRefresh, (v, windowInsets) -> {
-            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-            applySideInsetToMessagesList(Math.max(bars.left, bars.right));
-            return windowInsets;
-        });
-
         return mainView;
     }
 
@@ -397,7 +384,9 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
         baseMsgListPaddingLeft = jvcMsgList.getPaddingLeft();
         baseMsgListPaddingRight = jvcMsgList.getPaddingRight();
         jvcMsgList.setAdapter(adapterForTopic);
-        ViewCompat.requestApplyInsets(swipeRefresh);
+        /* Edge-to-edge : on capture l'inset latéral sur le parent de la liste (le SwipeRefreshLayout) et on
+           l'aiguille selon le mode d'affichage (cf. applySideInsetToMessagesList). */
+        Utils.forwardSymmetricSideInset(swipeRefresh, this::applySideInsetToMessagesList);
 
         if (savedInstanceState != null) {
             ArrayList<JVCParser.MessageInfos> allCurrentMessagesShowed = topicViewModel.listOfMessagesShowed;

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/JVCTopicAdapter.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/JVCTopicAdapter.java
@@ -83,6 +83,7 @@ public class JVCTopicAdapter extends BaseAdapter {
     private @ColorInt int deletedMessageBackgroundColor = 0;
     private @ColorInt int defaultMessageBackgroundColor = 0;
     private @ColorInt int altMessageBackgroundColor = 0;
+    private int sideInset = 0;
 
     private final PopupMenu.OnMenuItemClickListener menuItemInPopupMenuClickedListener = new PopupMenu.OnMenuItemClickListener() {
         @Override
@@ -308,6 +309,18 @@ public class JVCTopicAdapter extends BaseAdapter {
 
     public void setAltMessageBackgroundColor(@ColorInt int newColor) {
         altMessageBackgroundColor = newColor;
+    }
+
+    /* Edge-to-edge : inset latéral (barre de navigation et découpe du capteur) appliqué en padding sur
+       chaque ligne. Le fond de la ligne reste pleine largeur (passe sous le capteur en paysage) mais son
+       contenu est décalé pour ne pas passer dessous. On applique la même valeur des deux côtés pour garder
+       un décalage symétrique quel que soit le côté du capteur. Le mode carte, lui, décale les cartes via une
+       marge (padding de la liste) et n'utilise pas cet inset. */
+    public void setSideInset(int newInset) {
+        if (sideInset != newInset) {
+            sideInset = newInset;
+            notifyDataSetChanged();
+        }
     }
 
     public void enableSurvey(String newSurveyTitle) {
@@ -619,6 +632,9 @@ public class JVCTopicAdapter extends BaseAdapter {
             }
         }
 
+        convertView.setPadding(viewHolder.basePaddingLeft + sideInset, convertView.getPaddingTop(),
+                viewHolder.basePaddingRight + sideInset, convertView.getPaddingBottom());
+
         return convertView;
     }
 
@@ -672,6 +688,8 @@ public class JVCTopicAdapter extends BaseAdapter {
         public final TextView signatureLine;
         public final View separator;
         public final ImageButton showMenuButton;
+        public final int basePaddingLeft;
+        public final int basePaddingRight;
 
         public CustomViewHolder(View itemView) {
             infoLine = itemView.findViewById(R.id.infos_text_jvcmessages_row);
@@ -680,6 +698,8 @@ public class JVCTopicAdapter extends BaseAdapter {
             signatureLine = itemView.findViewById(R.id.signature_text_jvcmessages_row);
             separator = itemView.findViewById(R.id.separator_view_jvcmessages_row);
             showMenuButton = itemView.findViewById(R.id.menuoverflow_image_jvcmessages_row);
+            basePaddingLeft = itemView.getPaddingLeft();
+            basePaddingRight = itemView.getPaddingRight();
 
             infoLine.setSpannableFactory(spannableFactory);
             messageLine.setSpannableFactory(spannableFactory);

--- a/app/src/main/java/com/franckrj/respawnirc/utils/Utils.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/Utils.java
@@ -27,6 +27,7 @@ import android.webkit.CookieManager;
 import android.widget.EditText;
 
 import androidx.annotation.ColorInt;
+import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.emoji.text.EmojiCompat;
@@ -561,6 +562,20 @@ public class Utils {
             int navBottom = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
             int imeBottom = windowInsets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
             v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), basePadding + Math.max(navBottom, imeBottom));
+            return windowInsets;
+        });
+    }
+
+    /* Edge-to-edge : ajoute un padding latéral symétrique (le max des insets gauche/droite de barre de
+       navigation et découpe du capteur) pour que le contenu reste centré sans passer sous le capteur en
+       paysage. Le fond de la vue reste pleine largeur. */
+    public static void addSymmetricSideInsetPadding(final View view) {
+        final int basePaddingLeft = view.getPaddingLeft();
+        final int basePaddingRight = view.getPaddingRight();
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> {
+            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            int side = Math.max(bars.left, bars.right);
+            v.setPadding(basePaddingLeft + side, v.getPaddingTop(), basePaddingRight + side, v.getPaddingBottom());
             return windowInsets;
         });
     }

--- a/app/src/main/java/com/franckrj/respawnirc/utils/Utils.java
+++ b/app/src/main/java/com/franckrj/respawnirc/utils/Utils.java
@@ -566,21 +566,41 @@ public class Utils {
         });
     }
 
-    /* Edge-to-edge : ajoute un padding latéral symétrique (le max des insets gauche/droite de barre de
-       navigation et découpe du capteur) pour que le contenu reste centré sans passer sous le capteur en
-       paysage. Le fond de la vue reste pleine largeur. */
+    /* Edge-to-edge : inset latéral symétrique à appliquer — le max des insets gauche/droite de barre de
+       navigation et découpe du capteur — pour un décalage identique quel que soit le côté du capteur. */
+    public static int getSymmetricSideInset(WindowInsetsCompat windowInsets) {
+        Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+        return Math.max(bars.left, bars.right);
+    }
+
+    /* Edge-to-edge : ajoute un padding latéral symétrique (cf. getSymmetricSideInset) pour que le contenu
+       reste centré sans passer sous le capteur en paysage. Le fond de la vue reste pleine largeur. */
     public static void addSymmetricSideInsetPadding(final View view) {
         final int basePaddingLeft = view.getPaddingLeft();
         final int basePaddingRight = view.getPaddingRight();
         ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> {
-            Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-            int side = Math.max(bars.left, bars.right);
+            int side = getSymmetricSideInset(windowInsets);
             v.setPadding(basePaddingLeft + side, v.getPaddingTop(), basePaddingRight + side, v.getPaddingBottom());
             return windowInsets;
         });
     }
 
+    /* Edge-to-edge : capture l'inset latéral symétrique sur une vue parent (typiquement le SwipeRefreshLayout
+       d'une liste, dont les lignes gèrent elles-mêmes leur décalage) et le transmet à la cible sans consommer
+       les insets, pour que les enfants reçoivent quand même les leurs. Applique aussi la valeur courante. */
+    public static void forwardSymmetricSideInset(final View parent, final SideInsetTarget target) {
+        ViewCompat.setOnApplyWindowInsetsListener(parent, (v, windowInsets) -> {
+            target.onSideInset(getSymmetricSideInset(windowInsets));
+            return windowInsets;
+        });
+        ViewCompat.requestApplyInsets(parent);
+    }
+
     public interface StringModifier {
         String changeString(String baseString);
+    }
+
+    public interface SideInsetTarget {
+        void onSideInset(int sideInset);
     }
 }

--- a/app/src/main/res/layout/activity_selectforum.xml
+++ b/app/src/main/res/layout/activity_selectforum.xml
@@ -40,6 +40,7 @@
             android:layout_height="match_parent"
             android:layout_below="@+id/toolbar_selectforum">
             <LinearLayout
+                android:id="@+id/forumlist_cards_layout_selectforum"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:padding="@dimen/spaceAroundSingleCard"


### PR DESCRIPTION
Laisse de l’espace pour le sensor en mode paysage, au lieu que le contenu passe en dessous, et fait la même chose de l’autre côté de l’écran pour avoir de la symétrie.

<img width="2400" height="1080" alt="Screenshot_20260720_201908" src="https://github.com/user-attachments/assets/0660b21f-4e3b-4c3b-9832-96cc7541da17" />
<img width="2400" height="1080" alt="Screenshot_20260720_234454" src="https://github.com/user-attachments/assets/9deda3df-5235-4b9a-964f-a05f2a375ee4" />

Gérés :
- Liste des topics d’un forum
- Liste des messages d’un topic
- Barre de navigation de pages
- Toolbar (gère par défaut, symétrie rajoutée)
- Barre de rédaction/envoi d’un message
- Barre d’option recherche topic sujet/auteur/message
- Liste des forums
- Recherche de forums

Certains ont le fond en pleine taille (telle la liste des topics) avec juste le contenu décalé, certains ont le tout décalé (telle que la liste des messages quand c’est des cards), selon ce qui fait sens pour chaque.

Pas gérés :
- Zone de rédaction d’un message plein écran
- Poster un topic
- Préférences
- Drawer
- Sans doute d’autres que j’oublie