### PR TITLE
Build : Suppression de kotlinx-coroutines-core, redondante avec -android

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,5 @@ dependencies {
     implementation 'com.takisoft.preferencex:preferencex:1.1.0'
     implementation 'com.takisoft.preferencex:preferencex-colorpicker:1.1.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0'
     ksp 'com.github.bumptech.glide:ksp:5.0.9'
 }


### PR DESCRIPTION
`kotlinx-coroutines-core` est automatiquement importée par `kotlinx-coroutines-android`, et c’est juste cette dernière qu’on est censé déclarer : https://github.com/Kotlin/kotlinx.coroutines/blob/master/README.md#android