### PR TITLE
Correction du scroll automatique qui remontait au début du dernier message

### DIFF
--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/AbsShowTopicFragment.java
@@ -35,6 +35,8 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
     public static final int MODE_IRC = 0;
     public static final int MODE_FORUM = 1;
 
+    private static final int DURATION_OF_SMOOTH_SCROLL_IN_MS = 200;
+
     protected static final String SAVE_GO_TO_BOTTOM_PAGE_LOADING = "saveGoToBottomPageLoading";
     protected static final String SAVE_ANCHOR_FOR_NEXT_LOAD = "saveAnchorForNextLoad";
     protected static final String SAVE_SETTINGS_PSEUDO_OF_AUTHOR = "saveSettingsPseudoOfAuthor";
@@ -245,6 +247,37 @@ public abstract class AbsShowTopicFragment extends AbsShowSomethingFragment {
                     (jvcMsgList.getChildAt(jvcMsgList.getChildCount() - 1).getBottom() <= jvcMsgList.getHeight());
         }
         return true;
+    }
+
+    protected void scrollJvcMsgListToBottom(boolean useSmoothScroll) {
+        if (useSmoothScroll) {
+            /* Le scroll doit être fait après le layout provoqué par la mise à jour des messages, sinon la position
+             * des vues sur laquelle il se base est celle d'avant la mise à jour. */
+            jvcMsgList.post(this::smoothScrollJvcMsgListToBottom);
+        } else {
+            /* Le mode transcript aligne le bas du dernier message sur le bas de la liste, contrairement à
+             * setSelection qui aligne son haut sur le haut de la liste. */
+            jvcMsgList.setTranscriptMode(AbsListView.TRANSCRIPT_MODE_ALWAYS_SCROLL);
+        }
+    }
+
+    private void smoothScrollJvcMsgListToBottom() {
+        int lastPosition = jvcMsgList.getCount() - 1;
+
+        if (lastPosition < 0) {
+            return;
+        }
+
+        if (jvcMsgList.getLastVisiblePosition() < lastPosition) {
+            jvcMsgList.smoothScrollToPosition(lastPosition);
+        } else if (jvcMsgList.getChildCount() > 0) {
+            View lastMessageView = jvcMsgList.getChildAt(jvcMsgList.getChildCount() - 1);
+            int distanceToBottom = lastMessageView.getBottom() - (jvcMsgList.getHeight() - jvcMsgList.getPaddingBottom());
+
+            if (distanceToBottom > 0) {
+                jvcMsgList.smoothScrollBy(distanceToBottom, DURATION_OF_SMOOTH_SCROLL_IN_MS);
+            }
+        }
     }
 
     protected void setErrorBackgroundMessageDependingOnLastError() {

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicModeForumFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicModeForumFragment.java
@@ -167,11 +167,8 @@ public class ShowTopicModeForumFragment extends AbsShowTopicFragment {
                         jvcMsgList.setSelection(positionOfAnchor);
                     }
                 } else if (goToBottomAtPageLoading || (autoScrollIsEnabled && scrolledAtTheEnd)) {
-                    if (smoothScrollIsEnabled && scrolledAtTheEnd) { //s'il y avait des messages affichés avant et qu'on était en bas de page, smoothscroll
-                        jvcMsgList.smoothScrollToPosition(adapterForTopic.getCount() - 1);
-                    } else {
-                        jvcMsgList.setSelection(adapterForTopic.getCount() - 1);
-                    }
+                    //s'il y avait des messages affichés avant et qu'on était en bas de page, smoothscroll
+                    scrollJvcMsgListToBottom(smoothScrollIsEnabled && scrolledAtTheEnd);
                 }
             }
             goToBottomAtPageLoading = false;

--- a/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicModeIRCFragment.java
+++ b/app/src/main/java/com/franckrj/respawnirc/jvctopic/jvctopicviewers/ShowTopicModeIRCFragment.java
@@ -152,11 +152,8 @@ public class ShowTopicModeIRCFragment extends AbsShowTopicFragment {
                 allMessagesShowedAreFromIgnoredPseudos = false;
 
                 if (scrolledAtTheEnd) {
-                    if (smoothScrollIsEnabled && needASmoothScroll) { //s'il y avait des messages affichés avant et qu'on était en bas de page, smoothscroll
-                        jvcMsgList.smoothScrollToPosition(adapterForTopic.getCount() - 1);
-                    } else {
-                        jvcMsgList.setSelection(adapterForTopic.getCount() - 1);
-                    }
+                    //s'il y avait des messages affichés avant et qu'on était en bas de page, smoothscroll
+                    scrollJvcMsgListToBottom(smoothScrollIsEnabled && needASmoothScroll);
                 }
             }
         } else if (itsReallyEmpty) {


### PR DESCRIPTION
> Quand le dernier message était plus grand que l'écran et qu'on rafraichissait en étant tout en bas, la vue remontait pour afficher le haut de ce message au lieu de rester en bas : setSelection aligne le haut de l'item visé sur le haut de la liste, et smoothScrollToPosition fait pareil quand l'item est déjà partiellement visible (AbsListView.PositionScroller.scrollToVisible privilégie le bord haut).
> 
> Le saut instantané passe donc par TRANSCRIPT_MODE_ALWAYS_SCROLL, qui fait le layout à partir du bas de la liste, et le scroll animé calcule lui-même la distance restante après le layout provoqué par les nouveaux messages (avec repli sur smoothScrollToPosition quand le dernier message est encore hors écran, cas où celui-ci finit bien aligné en bas).
> 
> Corrige #1.

Je n’ai pas personnellement testé ; Claude a testé dans l’émulateur :

| cas | résultat |
|---|---|
| build sans le correctif, en bas + appui long | la vue quitte le bas ✗ (bug reproduit) |
| avec le correctif, smooth scroll activé (défaut) | reste en bas ✓ |
| avec le correctif, smooth scroll désactivé | reste en bas ✓ |
| rafraichissement au milieu de la page | position inchangée ✓ (pas de saut en bas parasite) |
| bascule en mode IRC | contenu court aligné en haut, pas de crash ✓ |
